### PR TITLE
feat(opcua): discover and inspect Method Nodes

### DIFF
--- a/app.go
+++ b/app.go
@@ -117,6 +117,11 @@ type WatchlistRowView struct {
 	DetailsError    string            `json:"detailsError"`
 }
 
+type MethodNodeRequest struct {
+	ObjectNodeID string `json:"objectNodeID"`
+	MethodNodeID string `json:"methodNodeID"`
+}
+
 type VariableNodeWriteRequest struct {
 	NodeID      string `json:"nodeID"`
 	TargetValue string `json:"targetValue"`
@@ -436,6 +441,27 @@ func (a *App) SearchAddressSpace(query string) (search.AddressSpaceSearchView, e
 		return search.AddressSpaceSearchView{Query: query, Results: []search.AddressSpaceSearchResult{}, Status: "Connect to an OPC UA Server to search browsed Address Space metadata."}, nil
 	}
 	return searchSession.Search(query), nil
+}
+
+func (a *App) GetMethodDetails(request MethodNodeRequest) (opcua.MethodDetails, error) {
+	a.mu.Lock()
+	connected := a.connected
+	client := a.client
+	a.mu.Unlock()
+	if !connected {
+		return opcua.MethodDetails{}, fmt.Errorf("Method inspection requires a connected session")
+	}
+	if strings.TrimSpace(request.ObjectNodeID) == "" || strings.TrimSpace(request.MethodNodeID) == "" {
+		return opcua.MethodDetails{}, fmt.Errorf("Method inspection requires Object and Method Node IDs")
+	}
+
+	a.appendLog("info", fmt.Sprintf("Reading Method details for Object Node %s Method Node %s", request.ObjectNodeID, request.MethodNodeID))
+	details, err := client.ReadMethodDetails(a.ctx, request.ObjectNodeID, request.MethodNodeID)
+	if err != nil {
+		a.appendLog("error", fmt.Sprintf("Reading Method details failed for Object Node %s Method Node %s: %v", request.ObjectNodeID, request.MethodNodeID, err))
+		return opcua.MethodDetails{}, err
+	}
+	return details, nil
 }
 
 func (a *App) InspectVariableNode(node opcua.AddressNode) error {

--- a/app_test.go
+++ b/app_test.go
@@ -21,22 +21,25 @@ func configureSearchSession(app *App, options search.SessionOptions) {
 }
 
 type recordingClient struct {
-	mu               sync.Mutex
-	connectErr       error
-	closeErr         error
-	connectRequests  []opcua.ConnectRequest
-	browseChildren   map[string][]opcua.AddressNode
-	browseErrors     map[string]error
-	browseRequests   []string
-	browseTimes      []time.Time
-	browseContexts   []context.Context
-	readValues       map[string]opcua.LiveValue
-	readValueErrors  map[string]error
-	readValueIDs     []string
-	readDetails      map[string]opcua.NodeDetails
-	readDetailErrors map[string]error
-	writeErrors      map[string]error
-	writeRequests    []recordedWrite
+	mu                   sync.Mutex
+	connectErr           error
+	closeErr             error
+	connectRequests      []opcua.ConnectRequest
+	browseChildren       map[string][]opcua.AddressNode
+	browseErrors         map[string]error
+	browseRequests       []string
+	browseTimes          []time.Time
+	browseContexts       []context.Context
+	readValues           map[string]opcua.LiveValue
+	readValueErrors      map[string]error
+	readValueIDs         []string
+	readDetails          map[string]opcua.NodeDetails
+	readDetailErrors     map[string]error
+	methodDetails        map[string]opcua.MethodDetails
+	methodDetailErrors   map[string]error
+	methodDetailRequests []MethodNodeRequest
+	writeErrors          map[string]error
+	writeRequests        []recordedWrite
 }
 
 type recordedWrite struct {
@@ -104,6 +107,17 @@ func (c *recordingClient) ReadNodeDetails(_ context.Context, nodeID string) (opc
 		return opcua.NodeDetails{}, nil
 	}
 	return c.readDetails[nodeID], nil
+}
+
+func (c *recordingClient) ReadMethodDetails(_ context.Context, objectNodeID, methodNodeID string) (opcua.MethodDetails, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	request := MethodNodeRequest{ObjectNodeID: objectNodeID, MethodNodeID: methodNodeID}
+	c.methodDetailRequests = append(c.methodDetailRequests, request)
+	if err := c.methodDetailErrors[objectNodeID+"\x00"+methodNodeID]; err != nil {
+		return opcua.MethodDetails{}, err
+	}
+	return c.methodDetails[objectNodeID+"\x00"+methodNodeID], nil
 }
 
 func (c *recordingClient) ReadValue(_ context.Context, nodeID string) (opcua.LiveValue, error) {
@@ -525,6 +539,39 @@ func TestExplicitBrowseAddsDiscoveredChildrenToSearchImmediately(t *testing.T) {
 	}
 	if len(view.Results) != 1 || view.Results[0].Node.NodeID != "ns=2;s=ManualTemperature" {
 		t.Fatalf("SearchAddressSpace() = %#v, want explicitly browsed child immediately searchable", view)
+	}
+}
+
+func TestGetMethodDetailsRequiresConnectionButIsAllowedInReadOnlyMode(t *testing.T) {
+	request := MethodNodeRequest{ObjectNodeID: "ns=3;s=Demo.CTT.Methods", MethodNodeID: "ns=3;s=Demo.CTT.Methods.MethodIO"}
+	details := opcua.MethodDetails{
+		ObjectNodeID:    request.ObjectNodeID,
+		MethodNodeID:    request.MethodNodeID,
+		Description:     "Adds 2 unsigned integers",
+		Executable:      true,
+		UserExecutable:  true,
+		InputArguments:  []opcua.MethodArgument{{Name: "Summand1", DataType: "UInt32"}, {Name: "Summand2", DataType: "UInt32"}},
+		OutputArguments: []opcua.MethodArgument{{Name: "Sum", DataType: "UInt32"}},
+	}
+	client := &recordingClient{methodDetails: map[string]opcua.MethodDetails{request.ObjectNodeID + "\x00" + request.MethodNodeID: details}}
+	app := NewAppWithSavedConnectionStore(t.TempDir() + "/saved-connections.json")
+	app.client = client
+
+	if _, err := app.GetMethodDetails(request); err == nil || !strings.Contains(err.Error(), "connected session") {
+		t.Fatalf("GetMethodDetails() disconnected error = %v, want connected session error", err)
+	}
+	app.connected = true
+	app.readOnlyMode = true
+
+	got, err := app.GetMethodDetails(request)
+	if err != nil {
+		t.Fatalf("GetMethodDetails() in Read-Only Mode error = %v", err)
+	}
+	if got.MethodNodeID != details.MethodNodeID || len(got.InputArguments) != 2 || got.OutputArguments[0].Name != "Sum" {
+		t.Fatalf("GetMethodDetails() = %#v, want MethodIO metadata", got)
+	}
+	if len(client.methodDetailRequests) != 1 || client.methodDetailRequests[0] != request {
+		t.Fatalf("ReadMethodDetails requests = %#v, want %#v", client.methodDetailRequests, request)
 	}
 }
 

--- a/internal/opcua/client.go
+++ b/internal/opcua/client.go
@@ -26,6 +26,7 @@ type Client interface {
 	Connect(ctx context.Context, request ConnectRequest) error
 	BrowseChildren(ctx context.Context, nodeID string) ([]AddressNode, error)
 	ReadNodeDetails(ctx context.Context, nodeID string) (NodeDetails, error)
+	ReadMethodDetails(ctx context.Context, objectNodeID, methodNodeID string) (MethodDetails, error)
 	ReadValue(ctx context.Context, nodeID string) (LiveValue, error)
 	WriteValue(ctx context.Context, nodeID string, value ScalarValue) error
 	SubscribeValue(ctx context.Context, nodeID string) (<-chan LiveValue, ValueSubscription, error)
@@ -61,10 +62,11 @@ type ConnectRequest struct {
 
 // AddressNode is the app-level projection of a browsed Address Space node.
 type AddressNode struct {
-	NodeID      string
-	DisplayName string
-	BrowseName  string
-	NodeClass   string
+	ParentNodeID string
+	NodeID       string
+	DisplayName  string
+	BrowseName   string
+	NodeClass    string
 }
 
 // LiveValue is the app-level projection of a subscribed Variable Node value.
@@ -218,10 +220,7 @@ func (c *gopcuaClient) BrowseChildren(ctx context.Context, nodeID string) ([]Add
 		return nil, err
 	}
 
-	nodes := make([]AddressNode, 0, len(refs))
-	for _, ref := range refs {
-		nodes = append(nodes, addressNodeFromReference(ref))
-	}
+	nodes := addressNodesFromReferences(nodeID, refs)
 	sort.SliceStable(nodes, func(i, j int) bool {
 		return strings.ToLower(nodes[i].DisplayName) < strings.ToLower(nodes[j].DisplayName)
 	})
@@ -419,6 +418,16 @@ func liveValueFromDataValue(nodeID string, data *ua.DataValue) LiveValue {
 }
 
 var opcuaSubscriptionInterval = 1 * time.Second
+
+func addressNodesFromReferences(parentNodeID string, refs []*ua.ReferenceDescription) []AddressNode {
+	nodes := make([]AddressNode, 0, len(refs))
+	for _, ref := range refs {
+		child := addressNodeFromReference(ref)
+		child.ParentNodeID = parentNodeID
+		nodes = append(nodes, child)
+	}
+	return nodes
+}
 
 func addressNodeFromReference(ref *ua.ReferenceDescription) AddressNode {
 	nodeID := ""

--- a/internal/opcua/client_integration_test.go
+++ b/internal/opcua/client_integration_test.go
@@ -45,6 +45,74 @@ func TestIntegrationBrowseObjectsRoot(t *testing.T) {
 	}
 }
 
+func TestIntegrationReadMethodIOMetadata(t *testing.T) {
+	endpoint := os.Getenv("TERMUA_METHOD_TEST_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("set TERMUA_METHOD_TEST_ENDPOINT to run Method metadata integration test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	client := NewClient()
+	endpoints, err := client.DiscoverEndpoints(ctx, endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(endpoints) == 0 {
+		t.Fatal("expected at least one endpoint")
+	}
+	selected := endpoints[0]
+	for _, candidate := range endpoints {
+		if candidate.SecurityMode == "None" && candidate.SecurityPolicy == "None" {
+			selected = candidate
+			break
+		}
+	}
+	if err := client.Connect(ctx, ConnectRequest{Endpoint: endpoint, SecurityMode: selected.SecurityMode, SecurityPolicy: selected.SecurityPolicy, AuthType: AuthAnonymous}); err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close(context.Background())
+
+	const objectNodeID = "ns=3;s=Demo.CTT.Methods"
+	const methodNodeID = "ns=3;s=Demo.CTT.Methods.MethodIO"
+	children, err := client.BrowseChildren(ctx, objectNodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, child := range children {
+		if child.NodeID == methodNodeID {
+			found = true
+			if child.ParentNodeID != objectNodeID || child.NodeClass != "Method" {
+				t.Fatalf("MethodIO Address Node = %#v, want owning Object Node and Method class", child)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("MethodIO not found below %s", objectNodeID)
+	}
+
+	details, err := client.ReadMethodDetails(ctx, objectNodeID, methodNodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !details.Executable || !details.UserExecutable {
+		t.Fatalf("MethodIO executable state = %#v, want executable for current user", details)
+	}
+	if len(details.InputArguments) != 2 || details.InputArguments[0].Name != "Summand1" || details.InputArguments[1].Name != "Summand2" {
+		t.Fatalf("MethodIO inputs = %#v, want ordered Summand1 and Summand2", details.InputArguments)
+	}
+	for _, argument := range details.InputArguments {
+		if argument.DataType != "UInt32" || argument.DataTypeID != "i=7" || argument.ValueRank != "Scalar" {
+			t.Fatalf("MethodIO input = %#v, want scalar UInt32", argument)
+		}
+	}
+	if len(details.OutputArguments) != 1 || details.OutputArguments[0].Name != "Sum" || details.OutputArguments[0].DataType != "UInt32" || details.OutputArguments[0].ValueRank != "Scalar" {
+		t.Fatalf("MethodIO outputs = %#v, want scalar UInt32 Sum", details.OutputArguments)
+	}
+}
+
 func TestIntegrationDiscoverEndpoints(t *testing.T) {
 	endpoint := os.Getenv("TERMUA_TEST_ENDPOINT")
 	if endpoint == "" {

--- a/internal/opcua/client_method_details_test.go
+++ b/internal/opcua/client_method_details_test.go
@@ -1,0 +1,109 @@
+package opcua
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+)
+
+func TestBrowsedMethodCarriesOwningObjectNodeID(t *testing.T) {
+	refs := []*ua.ReferenceDescription{{
+		NodeID:      ua.NewExpandedNodeID(ua.NewStringNodeID(2, "SharedReset"), "", 0),
+		DisplayName: ua.NewLocalizedText("Reset"),
+		BrowseName:  &ua.QualifiedName{NamespaceIndex: 2, Name: "Reset"},
+		NodeClass:   ua.NodeClassMethod,
+	}}
+
+	nodes := addressNodesFromReferences("ns=2;s=MotorA", refs)
+
+	if len(nodes) != 1 || nodes[0].ParentNodeID != "ns=2;s=MotorA" || nodes[0].NodeID != "ns=2;s=SharedReset" || nodes[0].NodeClass != "Method" {
+		t.Fatalf("browsed Method = %#v, want owning Object Node identity", nodes)
+	}
+}
+
+func TestMethodAttributesExposeDescriptionAndExecutableState(t *testing.T) {
+	details := MethodDetails{}
+	attrs := []*ua.DataValue{
+		{Status: ua.StatusOK, Value: ua.MustVariant(ua.NewLocalizedText("Adds 2 unsigned integers"))},
+		{Status: ua.StatusOK, Value: ua.MustVariant(true)},
+		{Status: ua.StatusOK, Value: ua.MustVariant(false)},
+	}
+
+	if err := applyMethodAttributes(&details, attrs); err != nil {
+		t.Fatalf("applyMethodAttributes() error = %v", err)
+	}
+	if details.Description != "Adds 2 unsigned integers" || !details.Executable || details.UserExecutable {
+		t.Fatalf("Method attributes = %#v, want description, executable, and user not executable", details)
+	}
+}
+
+func TestMethodArgumentsPreserveDeclaredOrderAndMetadata(t *testing.T) {
+	value := ua.MustVariant([]*ua.ExtensionObject{
+		ua.NewExtensionObject(&ua.Argument{
+			Name:            "Summand1",
+			DataType:        ua.NewNumericNodeID(0, id.UInt32),
+			ValueRank:       -1,
+			ArrayDimensions: []uint32{},
+			Description:     ua.NewLocalizedText("First summand"),
+		}),
+		ua.NewExtensionObject(&ua.Argument{
+			Name:            "Summand2",
+			DataType:        ua.NewNumericNodeID(0, id.UInt32),
+			ValueRank:       -1,
+			ArrayDimensions: []uint32{},
+			Description:     ua.NewLocalizedText("Second summand"),
+		}),
+	})
+
+	arguments, err := methodArgumentsFromVariant(value)
+	if err != nil {
+		t.Fatalf("methodArgumentsFromVariant() error = %v", err)
+	}
+	if len(arguments) != 2 || arguments[0].Name != "Summand1" || arguments[1].Name != "Summand2" {
+		t.Fatalf("arguments = %#v, want declared order", arguments)
+	}
+	first := arguments[0]
+	if first.DataTypeID != "i=7" || first.DataType != "UInt32" || first.ValueRank != "Scalar" || first.Description != "First summand" || !first.Supported {
+		t.Fatalf("first argument = %#v, want scalar UInt32 metadata", first)
+	}
+	if first.ArrayDimensions == nil || len(first.ArrayDimensions) != 0 {
+		t.Fatalf("ArrayDimensions = %#v, want present empty dimensions", first.ArrayDimensions)
+	}
+}
+
+func TestMethodArgumentsMarkArraysAndCustomDataTypesUnsupported(t *testing.T) {
+	value := ua.MustVariant([]*ua.ExtensionObject{
+		ua.NewExtensionObject(&ua.Argument{Name: "Values", DataType: ua.NewNumericNodeID(0, id.Double), ValueRank: 1, ArrayDimensions: []uint32{4}}),
+		ua.NewExtensionObject(&ua.Argument{Name: "Recipe", DataType: ua.NewStringNodeID(2, "RecipeType"), ValueRank: -1}),
+	})
+
+	arguments, err := methodArgumentsFromVariant(value)
+	if err != nil {
+		t.Fatalf("methodArgumentsFromVariant() error = %v", err)
+	}
+	if arguments[0].Supported || arguments[0].ValueRank != "One-dimensional array" || len(arguments[0].ArrayDimensions) != 1 || arguments[0].ArrayDimensions[0] != 4 {
+		t.Fatalf("array argument = %#v, want unsupported one-dimensional array", arguments[0])
+	}
+	if arguments[1].Supported || arguments[1].DataTypeID != "ns=2;s=RecipeType" || arguments[1].DataType != "ns=2;s=RecipeType" {
+		t.Fatalf("custom argument = %#v, want unsupported custom DataType", arguments[1])
+	}
+}
+
+func TestMalformedMethodArgumentPropertyIsMetadataError(t *testing.T) {
+	_, err := methodArgumentsFromVariant(ua.MustVariant([]string{"not an Argument"}))
+	if err == nil || !strings.Contains(err.Error(), "ua.Argument") {
+		t.Fatalf("methodArgumentsFromVariant() error = %v, want malformed ua.Argument metadata error", err)
+	}
+}
+
+func TestUnreadableMethodArgumentPropertyIsMetadataError(t *testing.T) {
+	arguments, err := methodArgumentsFromProperty("InputArguments", nil, ua.StatusBadSecurityModeInsufficient)
+	if err == nil || !strings.Contains(err.Error(), "BadSecurityModeInsufficient") {
+		t.Fatalf("methodArgumentsFromProperty() error = %v, want secure-channel metadata error", err)
+	}
+	if arguments != nil {
+		t.Fatalf("methodArgumentsFromProperty() = %#v, want no empty signature on metadata failure", arguments)
+	}
+}

--- a/internal/opcua/method.go
+++ b/internal/opcua/method.go
@@ -1,0 +1,193 @@
+package opcua
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gopcua "github.com/gopcua/opcua"
+	"github.com/gopcua/opcua/id"
+	"github.com/gopcua/opcua/ua"
+)
+
+// MethodArgument is the app-level projection of one declared Method argument.
+type MethodArgument struct {
+	Name            string
+	DataType        string
+	DataTypeID      string
+	ValueRank       string
+	Description     string
+	ArrayDimensions []uint32
+	Supported       bool
+}
+
+// MethodDetails describes a Method Node and its ordered signature.
+type MethodDetails struct {
+	ObjectNodeID    string
+	MethodNodeID    string
+	Description     string
+	Executable      bool
+	UserExecutable  bool
+	InputArguments  []MethodArgument
+	OutputArguments []MethodArgument
+}
+
+func (c *gopcuaClient) ReadMethodDetails(ctx context.Context, objectNodeID, methodNodeID string) (MethodDetails, error) {
+	if c.client == nil {
+		return MethodDetails{}, ua.StatusBadServerNotConnected
+	}
+	if _, err := ua.ParseNodeID(objectNodeID); err != nil {
+		return MethodDetails{}, fmt.Errorf("invalid Object Node ID: %w", err)
+	}
+	parsedMethodNodeID, err := ua.ParseNodeID(methodNodeID)
+	if err != nil {
+		return MethodDetails{}, fmt.Errorf("invalid Method Node ID: %w", err)
+	}
+
+	details := MethodDetails{
+		ObjectNodeID:    objectNodeID,
+		MethodNodeID:    methodNodeID,
+		InputArguments:  []MethodArgument{},
+		OutputArguments: []MethodArgument{},
+	}
+	methodNode := c.client.Node(parsedMethodNodeID)
+	attrs, err := methodNode.Attributes(ctx, ua.AttributeIDDescription, ua.AttributeIDExecutable, ua.AttributeIDUserExecutable)
+	if err != nil {
+		return MethodDetails{}, fmt.Errorf("read Method attributes: %w", err)
+	}
+	if err := applyMethodAttributes(&details, attrs); err != nil {
+		return MethodDetails{}, err
+	}
+	if err := c.applyMethodArgumentProperties(ctx, methodNode, &details); err != nil {
+		return MethodDetails{}, err
+	}
+	return details, nil
+}
+
+func applyMethodAttributes(details *MethodDetails, attrs []*ua.DataValue) error {
+	names := []string{"Description", "Executable", "UserExecutable"}
+	if len(attrs) != len(names) {
+		return fmt.Errorf("read Method attributes: got %d results, want %d", len(attrs), len(names))
+	}
+	for i, attr := range attrs {
+		if attr == nil {
+			return fmt.Errorf("read Method %s: empty result", names[i])
+		}
+		if attr.Status != ua.StatusOK {
+			return fmt.Errorf("read Method %s: %w", names[i], attr.Status)
+		}
+		if attr.Value == nil {
+			return fmt.Errorf("read Method %s: empty value", names[i])
+		}
+	}
+	details.Description = localizedTextValue(attrs[0].Value.Value())
+	var ok bool
+	details.Executable, ok = attrs[1].Value.Value().(bool)
+	if !ok {
+		return fmt.Errorf("read Method Executable: malformed %T value", attrs[1].Value.Value())
+	}
+	details.UserExecutable, ok = attrs[2].Value.Value().(bool)
+	if !ok {
+		return fmt.Errorf("read Method UserExecutable: malformed %T value", attrs[2].Value.Value())
+	}
+	return nil
+}
+
+func (c *gopcuaClient) applyMethodArgumentProperties(ctx context.Context, methodNode *gopcua.Node, details *MethodDetails) error {
+	refs, err := methodNode.References(ctx, id.HasProperty, ua.BrowseDirectionForward, ua.NodeClassVariable, true)
+	if err != nil {
+		return fmt.Errorf("browse Method argument properties: %w", err)
+	}
+	for _, ref := range refs {
+		property := addressNodeFromReference(ref)
+		name := strings.TrimPrefix(property.BrowseName, "0:")
+		if name != "InputArguments" && name != "OutputArguments" {
+			continue
+		}
+		propertyNodeID, err := ua.ParseNodeID(property.NodeID)
+		if err != nil {
+			return fmt.Errorf("read Method %s: invalid property Node ID: %w", name, err)
+		}
+		value, readErr := c.client.Node(propertyNodeID).Attribute(ctx, ua.AttributeIDValue)
+		arguments, err := methodArgumentsFromProperty(name, value, readErr)
+		if err != nil {
+			return err
+		}
+		if name == "InputArguments" {
+			details.InputArguments = arguments
+		} else {
+			details.OutputArguments = arguments
+		}
+	}
+	return nil
+}
+
+func methodArgumentsFromProperty(name string, value *ua.Variant, readErr error) ([]MethodArgument, error) {
+	if readErr != nil {
+		return nil, fmt.Errorf("read Method %s metadata: %w", name, readErr)
+	}
+	arguments, err := methodArgumentsFromVariant(value)
+	if err != nil {
+		return nil, fmt.Errorf("read Method %s: %w", name, err)
+	}
+	return arguments, nil
+}
+
+func methodArgumentsFromVariant(value *ua.Variant) ([]MethodArgument, error) {
+	if value == nil {
+		return nil, fmt.Errorf("malformed argument metadata: empty value, want ua.Argument array")
+	}
+
+	var extensionObjects []*ua.ExtensionObject
+	switch raw := value.Value().(type) {
+	case []*ua.ExtensionObject:
+		extensionObjects = raw
+	case []ua.ExtensionObject:
+		extensionObjects = make([]*ua.ExtensionObject, len(raw))
+		for i := range raw {
+			extensionObjects[i] = &raw[i]
+		}
+	default:
+		return nil, fmt.Errorf("malformed argument metadata: got %T, want ua.Argument array", value.Value())
+	}
+
+	arguments := make([]MethodArgument, 0, len(extensionObjects))
+	for i, extensionObject := range extensionObjects {
+		if extensionObject == nil {
+			return nil, fmt.Errorf("malformed argument metadata at index %d: empty ExtensionObject, want ua.Argument", i)
+		}
+		argument, ok := extensionObject.Value.(*ua.Argument)
+		if !ok || argument == nil {
+			return nil, fmt.Errorf("malformed argument metadata at index %d: got %T, want ua.Argument", i, extensionObject.Value)
+		}
+		arguments = append(arguments, methodArgumentFromUA(argument))
+	}
+	return arguments, nil
+}
+
+func methodArgumentFromUA(argument *ua.Argument) MethodArgument {
+	dataTypeID := ""
+	if argument.DataType != nil {
+		dataTypeID = argument.DataType.String()
+	}
+	dimensions := append([]uint32{}, argument.ArrayDimensions...)
+	dataType := dataTypeName(argument.DataType)
+	return MethodArgument{
+		Name:            argument.Name,
+		DataType:        dataType,
+		DataTypeID:      dataTypeID,
+		ValueRank:       valueRankText(argument.ValueRank),
+		Description:     localizedTextValue(argument.Description),
+		ArrayDimensions: dimensions,
+		Supported:       argument.ValueRank == -1 && supportedMethodDataType(dataType),
+	}
+}
+
+func supportedMethodDataType(dataType string) bool {
+	switch dataType {
+	case "Boolean", "SByte", "Byte", "Int16", "UInt16", "Int32", "UInt32", "Int64", "UInt64", "Float", "Double", "String":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/search/service.go
+++ b/internal/search/service.go
@@ -64,11 +64,12 @@ func (s *Service) AddNodes(nodes []opcua.AddressNode) {
 		if strings.TrimSpace(node.NodeID) == "" {
 			continue
 		}
-		if _, exists := s.nodes[node.NodeID]; exists {
+		identity := nodeIdentity(node)
+		if _, exists := s.nodes[identity]; exists {
 			continue
 		}
-		s.nodes[node.NodeID] = node
-		s.order = append(s.order, node.NodeID)
+		s.nodes[identity] = node
+		s.order = append(s.order, identity)
 	}
 }
 
@@ -82,8 +83,8 @@ func (s *Service) Search(query string) AddressSpaceSearchView {
 
 	s.mu.RLock()
 	results := make([]AddressSpaceSearchResult, 0, len(s.nodes))
-	for _, nodeID := range s.order {
-		node, ok := s.nodes[nodeID]
+	for _, identity := range s.order {
+		node, ok := s.nodes[identity]
 		if !ok {
 			continue
 		}
@@ -102,13 +103,23 @@ func (s *Service) Search(query string) AddressSpaceSearchView {
 		if left != right {
 			return left < right
 		}
-		return results[i].Node.NodeID < results[j].Node.NodeID
+		if results[i].Node.NodeID != results[j].Node.NodeID {
+			return results[i].Node.NodeID < results[j].Node.NodeID
+		}
+		return results[i].Node.ParentNodeID < results[j].Node.ParentNodeID
 	})
 	view.Results = results
 	if len(results) == 0 {
 		view.Status = "No matches in browsed Address Space metadata yet. Browse more nodes to expand Search."
 	}
 	return view
+}
+
+func nodeIdentity(node opcua.AddressNode) string {
+	if node.NodeClass == "Method" {
+		return node.ParentNodeID + "\x00" + node.NodeID
+	}
+	return node.NodeID
 }
 
 func matchNode(query string, node opcua.AddressNode) (AddressSpaceSearchResult, bool) {

--- a/internal/search/service_test.go
+++ b/internal/search/service_test.go
@@ -34,6 +34,27 @@ func TestDeduplicatesNodeIDs(t *testing.T) {
 	}
 }
 
+func TestSharedMethodNodeIDRemainsDistinctForEachOwningObjectNode(t *testing.T) {
+	service := NewService()
+	service.AddNodes([]opcua.AddressNode{
+		{ParentNodeID: "ns=2;s=MotorA", NodeID: "ns=2;s=Reset", DisplayName: "Reset", BrowseName: "2:Reset", NodeClass: "Method"},
+		{ParentNodeID: "ns=2;s=MotorB", NodeID: "ns=2;s=Reset", DisplayName: "Reset", BrowseName: "2:Reset", NodeClass: "Method"},
+	})
+
+	view := service.Search("Reset")
+
+	if len(view.Results) != 2 {
+		t.Fatalf("shared Method Search Results = %d, want one per owning Object Node", len(view.Results))
+	}
+	owners := map[string]bool{}
+	for _, result := range view.Results {
+		owners[result.Node.ParentNodeID] = true
+	}
+	if !owners["ns=2;s=MotorA"] || !owners["ns=2;s=MotorB"] {
+		t.Fatalf("shared Method owners = %#v, want MotorA and MotorB", owners)
+	}
+}
+
 func TestExactDisplayNameRanksAboveNodeIDSubstring(t *testing.T) {
 	service := NewService()
 	service.AddNodes([]opcua.AddressNode{


### PR DESCRIPTION
## Summary
- retain owning Object Node IDs while browsing and preserve shared Method identities in Address Space Search
- expose Method metadata and ordered input/output argument details through the OPC UA client
- add a connected-session Wails binding that remains available in Read-Only Mode
- cover metadata projection, search identity, App behavior, and the opt-in MethodIO integration tracer

## Tests
- `go test ./...`
- `go vet ./...`
- `TERMUA_METHOD_TEST_ENDPOINT` integration test not run because the endpoint is not configured

Closes #37
