### PR TITLE
feat(frontend): add Method Call panel

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -667,6 +667,7 @@ func TestCallMethodSafetyGatesPreventExecution(t *testing.T) {
 		{name: "unsupported type", connected: true, details: opcua.MethodDetails{Executable: true, UserExecutable: true, InputArguments: []opcua.MethodArgument{{DataType: "DateTime", ValueRank: "Scalar"}}}, inputs: []string{"now"}, want: "unsupported DataType"},
 		{name: "array", connected: true, details: opcua.MethodDetails{Executable: true, UserExecutable: true, InputArguments: []opcua.MethodArgument{{DataType: "UInt32", ValueRank: "One-dimensional array"}}}, inputs: []string{"42"}, want: "non-scalar"},
 		{name: "invalid value", connected: true, details: valid, inputs: []string{"314159-secret"}, want: "invalid UInt32"},
+		{name: "underflow", connected: true, details: opcua.MethodDetails{Executable: true, UserExecutable: true, InputArguments: []opcua.MethodArgument{{Name: "Value", DataType: "Double", ValueRank: "Scalar", Supported: true}}}, inputs: []string{"1e-999"}, want: "invalid Double"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -858,6 +859,27 @@ func TestWriteVariableNodeValueWritesTypedScalarAndRefreshesReadBack(t *testing.
 	selected, _ := app.inspections.Selected()
 	if selected.Value.Value != "42" || selected.UpdateCount != 2 || selected.Stale {
 		t.Fatalf("selected inspection after write = %#v", selected)
+	}
+}
+
+func TestWriteVariableNodeValueRejectsFloatUnderflowBeforeWriting(t *testing.T) {
+	node := opcua.AddressNode{NodeID: "ns=2;s=Level", DisplayName: "Tank Level", NodeClass: "Variable"}
+	details := opcua.NodeDetails{NodeID: node.NodeID, DataType: "Float", Writable: true, ValueRank: "Scalar"}
+	client := &recordingClient{readDetails: map[string]opcua.NodeDetails{node.NodeID: details}}
+	app := NewAppWithSavedConnectionStore(t.TempDir() + "/saved-connections.json")
+	app.client = client
+	app.connected = true
+	app.readOnlyMode = false
+	app.inspections.Select(node)
+	app.inspections.ApplyDetails(node.NodeID, details, nil)
+	app.inspections.ApplyLiveValue(node.NodeID, opcua.LiveValue{NodeID: node.NodeID, Value: "1", Status: "Good"}, nil)
+
+	_, err := app.WriteVariableNodeValue(VariableNodeWriteRequest{NodeID: node.NodeID, TargetValue: "1e-50"})
+	if err == nil || !strings.Contains(err.Error(), "invalid Float") {
+		t.Fatalf("WriteVariableNodeValue() error = %v, want invalid Float", err)
+	}
+	if len(client.writeRequests) != 0 {
+		t.Fatalf("write requests = %#v, want underflow rejected before client write", client.writeRequests)
 	}
 }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -554,16 +554,7 @@
   }
 
   async function selectNode(item: TreeNode) {
-    selectedNodeID = nodeSelectionKey(item.node)
-    if (item.node.NodeClass === 'Variable') {
-      resetMethodState()
-      await InspectVariableNode(item.node)
-    } else if (item.node.NodeClass === 'Method') {
-      await activateMethod(item.node)
-    } else {
-      resetMethodState()
-      await ClearVariableNodeInspection()
-    }
+    await activateAddressNode(item.node)
   }
 
   function resetSearchView() {
@@ -594,12 +585,16 @@
   }
 
   async function activateSearchResult(result: AddressSpaceSearchResult) {
-    selectedNodeID = nodeSelectionKey(result.node)
-    if (result.node.NodeClass === 'Variable') {
+    await activateAddressNode(result.node)
+  }
+
+  async function activateAddressNode(node: AddressNode) {
+    selectedNodeID = nodeSelectionKey(node)
+    if (node.NodeClass === 'Variable') {
       resetMethodState()
-      await InspectVariableNode(result.node)
-    } else if (result.node.NodeClass === 'Method') {
-      await activateMethod(result.node)
+      await InspectVariableNode(node)
+    } else if (node.NodeClass === 'Method') {
+      await activateMethod(node)
     } else {
       resetMethodState()
       await ClearVariableNodeInspection()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { BrowseChildren, CallMethod, ClearVariableNodeInspection, Connect, DeleteSavedConnection, Disconnect, DiscoverEndpoints, GetDiagnosticLogs, GetMethodDetails, GetSavedConnections, GetSessionSafety, GetSessionTrend, GetWatchlist, InspectVariableNode, PickClientCertificate, PickClientPrivateKey, RefreshVariableNodeValue, SaveSavedConnection, SearchAddressSpace, SetReadOnlyMode, UnwatchVariableNode, WatchVariableNode, WriteVariableNodeValue } from '../wailsjs/go/main/App.js'
+  import { BrowseChildren, ClearVariableNodeInspection, Connect, DeleteSavedConnection, Disconnect, DiscoverEndpoints, GetDiagnosticLogs, GetSavedConnections, GetSessionSafety, GetSessionTrend, GetWatchlist, InspectVariableNode, PickClientCertificate, PickClientPrivateKey, RefreshVariableNodeValue, SaveSavedConnection, SearchAddressSpace, SetReadOnlyMode, UnwatchVariableNode, WatchVariableNode, WriteVariableNodeValue } from '../wailsjs/go/main/App.js'
   import { EventsOn } from '../wailsjs/runtime/runtime.js'
+  import MethodCallPanel from './MethodCallPanel.svelte'
+  import { isSupportedScalarDataType, parseScalarInputError } from './scalarInput'
   import { getReadmeScreenshotState } from './readmeScreenshots'
 
   type Tab = 'connections' | 'address-space' | 'watchlist' | 'session-trend' | 'logs'
@@ -22,43 +24,6 @@
     DisplayName: string
     BrowseName: string
     NodeClass: string
-  }
-
-  type MethodArgument = {
-    Name: string
-    DataType: string
-    DataTypeID: string
-    ValueRank: string
-    Description: string
-    ArrayDimensions: number[]
-    Supported: boolean
-  }
-
-  type MethodDetails = {
-    ObjectNodeID: string
-    MethodNodeID: string
-    Description: string
-    Executable: boolean
-    UserExecutable: boolean
-    InputArguments: MethodArgument[]
-    OutputArguments: MethodArgument[]
-  }
-
-  type MethodCallResult = {
-    StatusCode: string
-    InputArgumentResults: string[]
-    OutputArguments: Array<{ DataType: string; Value: string }>
-  }
-
-  type MethodCallAvailability = {
-    selectedMethod: AddressNode | null
-    details: MethodDetails | null
-    detailsLoading: boolean
-    detailsError: string
-    inputs: string[]
-    submitting: boolean
-    connected: boolean
-    readOnlyMode: boolean
   }
 
   type AddressSpaceSearchResult = {
@@ -236,13 +201,6 @@
   let writeConfirmOpen = false
   let writeConfirmationSnapshot: WriteConfirmationSnapshot | null = null
   let selectedMethod: AddressNode | null = null
-  let methodDetails: MethodDetails | null = null
-  let methodDetailsLoading = false
-  let methodDetailsError = ''
-  let methodInputs: string[] = []
-  let methodSubmitting = false
-  let methodResult: MethodCallResult | null = null
-  let methodCallError = ''
 
   $: selectedEndpointInfo = endpoints[selectedEndpoint]
   $: selectedSecurityMode = selectedEndpointInfo?.SecurityMode?.replace('MessageSecurityMode', '').trim() || ''
@@ -259,8 +217,6 @@
   $: writeConfirmationInvalidated = isWriteConfirmationInvalidated(inspection, writeConfirmationSnapshot)
   $: writeRangeWarning = writeTargetRangeWarning(inspection, writeTargetValue)
   $: writeStatusWarning = inspection && !inspection.stale && inspection.value?.Status && !inspection.value.Status.includes('Good') ? `Current status is ${inspection.value.Status}; confirm the value is safe to change.` : ''
-  $: methodDisabledReasons = methodCallDisabledReasons({ selectedMethod, details: methodDetails, detailsLoading: methodDetailsLoading, detailsError: methodDetailsError, inputs: methodInputs, submitting: methodSubmitting, connected, readOnlyMode })
-  $: canCallMethod = !!selectedMethod && !!methodDetails && methodDisabledReasons.length === 0
 
   onMount(() => {
     let disposed = false
@@ -313,7 +269,6 @@
   function applySessionSafety(sessionSafety: SessionSafety) {
     connected = sessionSafety.connected
     readOnlyMode = sessionSafety.readOnlyMode
-    if (!sessionSafety.connected) resetMethodState()
   }
 
   function addToast(level: string, message: string) {
@@ -656,13 +611,6 @@
 
   function resetMethodState() {
     selectedMethod = null
-    methodDetails = null
-    methodDetailsLoading = false
-    methodDetailsError = ''
-    methodInputs = []
-    methodSubmitting = false
-    methodResult = null
-    methodCallError = ''
   }
 
   async function activateMethod(node: AddressNode) {
@@ -670,73 +618,7 @@
     resetWriteState()
     inspection = null
     selectedMethod = node
-    methodDetailsLoading = true
-    const selectionKey = nodeSelectionKey(node)
     await ClearVariableNodeInspection()
-    try {
-      const details = await GetMethodDetails({ objectNodeID: node.ParentNodeID || '', methodNodeID: node.NodeID })
-      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) {
-        methodDetails = { ...details, InputArguments: details.InputArguments || [], OutputArguments: details.OutputArguments || [] }
-        methodInputs = methodDetails.InputArguments.map(() => '')
-      }
-    } catch (error) {
-      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) methodDetailsError = String(error)
-    } finally {
-      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) methodDetailsLoading = false
-    }
-  }
-
-  function updateMethodInput(index: number, value: string) {
-    methodInputs = methodInputs.map((current, currentIndex) => currentIndex === index ? value : current)
-    methodResult = null
-    methodCallError = ''
-  }
-
-  function methodCallDisabledReasons(state: MethodCallAvailability) {
-    const reasons: string[] = []
-    if (!state.connected) reasons.push('Connect to an OPC UA Server before calling a Method.')
-    if (state.readOnlyMode) reasons.push('Read-Only Mode is active.')
-    if (state.detailsLoading) reasons.push('Method metadata is loading.')
-    if (state.detailsError) reasons.push(`Method metadata failed to load: ${state.detailsError}`)
-    if (!state.selectedMethod) return reasons
-    if (!state.details && !state.detailsLoading && !state.detailsError) reasons.push('Method metadata is unavailable.')
-    if (!state.details) return reasons
-    if (!state.details.Executable) reasons.push('Method is not executable.')
-    else if (!state.details.UserExecutable) reasons.push('Method is not executable for the current session.')
-    state.details.InputArguments.forEach((argument, index) => {
-      const unsupportedType = !isSupportedWriteDataType(argument.DataType)
-      const unsupportedRank = argument.ValueRank !== 'Scalar'
-      if (!argument.Supported || unsupportedType || unsupportedRank) {
-        const limitations = [unsupportedType ? `DataType ${argument.DataType}` : '', unsupportedRank ? `ValueRank ${argument.ValueRank}` : ''].filter(Boolean).join(' and ')
-        reasons.push(`${argument.Name || `Input ${index + 1}`} uses unsupported ${limitations || 'argument metadata'}.`)
-        return
-      }
-      const error = parseScalarInputError(argument.DataType, state.inputs[index] || '', argument.Name || `Input ${index + 1}`)
-      if (error) reasons.push(error)
-    })
-    if (state.submitting) reasons.push('Method call is in progress.')
-    return reasons
-  }
-
-  async function submitMethodCall() {
-    if (!selectedMethod || !methodDetails || !canCallMethod || methodSubmitting) return
-    const selectionKey = nodeSelectionKey(selectedMethod)
-    methodSubmitting = true
-    methodResult = null
-    methodCallError = ''
-    try {
-      const result = await CallMethod({ objectNodeID: methodDetails.ObjectNodeID, methodNodeID: methodDetails.MethodNodeID, inputArguments: methodInputs })
-      if (!selectedMethod || nodeSelectionKey(selectedMethod) !== selectionKey) return
-      methodResult = { ...result, InputArgumentResults: result.InputArgumentResults || [], OutputArguments: result.OutputArguments || [] }
-      if (result.StatusCode.includes('Good')) addToast('info', `Method call completed: ${result.StatusCode}`)
-      else addToast('error', `Method call returned ${result.StatusCode}`)
-    } catch (error) {
-      if (!selectedMethod || nodeSelectionKey(selectedMethod) !== selectionKey) return
-      methodCallError = `Method call failed: ${String(error)}`
-      addToast('error', methodCallError)
-    } finally {
-      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) methodSubmitting = false
-    }
   }
 
   function methodObjectName() {
@@ -809,7 +691,7 @@
     } else {
       if (current.details.ValueRank && current.details.ValueRank !== 'Scalar') reasons.push(`Only scalar Variable Node Writes are supported; ValueRank is ${current.details.ValueRank}.`)
       if (!current.details.Writable) reasons.push(current.details.WriteAvailability || 'Effective metadata says this Variable Node is not writable in this session.')
-      if (current.details.DataType && !isSupportedWriteDataType(current.details.DataType)) reasons.push(`Data type ${current.details.DataType} is not supported for Variable Node Write.`)
+      if (current.details.DataType && !isSupportedScalarDataType(current.details.DataType)) reasons.push(`Data type ${current.details.DataType} is not supported for Variable Node Write.`)
       if (!current.details.DataType) reasons.push('Data type is unavailable.')
     }
     if (current.stale) reasons.push('Current Live Value is stale.')
@@ -819,35 +701,8 @@
     return reasons
   }
 
-  function isSupportedWriteDataType(dataType: string) {
-    return ['Boolean', 'SByte', 'Int16', 'Int32', 'Int64', 'Byte', 'UInt16', 'UInt32', 'UInt64', 'Float', 'Double', 'String'].includes(dataType.trim())
-  }
-
   function parseWriteTargetError(dataType: string, target: string) {
     return parseScalarInputError(dataType, target, 'Target Value')
-  }
-
-  function parseScalarInputError(dataType: string, target: string, label: string) {
-    const trimmed = target.trim()
-    if (!dataType || !isSupportedWriteDataType(dataType)) return ''
-    if (dataType === 'String') return ''
-    if (!trimmed) return label === 'Target Value' ? 'Enter a Target Value.' : `Enter a value for ${label}.`
-    if (dataType === 'Boolean') return ['true', 'false', '1', '0', 'on', 'off', 'yes', 'no'].includes(trimmed.toLowerCase()) ? '' : `${label} must parse as Boolean.`
-    if (['Float', 'Double'].includes(dataType)) {
-      const decimalFloatPattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
-      const parsed = Number(trimmed)
-      const inRange = Number.isFinite(parsed) && (dataType !== 'Float' || Number.isFinite(Math.fround(parsed)))
-      return decimalFloatPattern.test(trimmed) && inRange ? '' : `${label} must parse as ${dataType}.`
-    }
-    if (!/^[+]?\d+$/.test(trimmed) && ['Byte', 'UInt16', 'UInt32', 'UInt64'].includes(dataType)) return `${label} must be an unsigned plain decimal integer for ${dataType}.`
-    if (!/^[+-]?\d+$/.test(trimmed)) return `${label} must be a plain decimal integer for ${dataType}.`
-    const value = BigInt(trimmed)
-    const ranges: Record<string, [bigint, bigint]> = {
-      SByte: [BigInt('-128'), BigInt('127')], Int16: [BigInt('-32768'), BigInt('32767')], Int32: [BigInt('-2147483648'), BigInt('2147483647')], Int64: [BigInt('-9223372036854775808'), BigInt('9223372036854775807')],
-      Byte: [BigInt('0'), BigInt('255')], UInt16: [BigInt('0'), BigInt('65535')], UInt32: [BigInt('0'), BigInt('4294967295')], UInt64: [BigInt('0'), BigInt('18446744073709551615')]
-    }
-    const [min, max] = ranges[dataType]
-    return value < min || value > max ? `${label} is outside ${dataType} range.` : ''
   }
 
   function writeTargetRangeWarning(current: Inspection | null, target: string) {
@@ -1283,91 +1138,16 @@
             </div>
             <div class="min-h-0 flex-1 overflow-auto p-lg">
               {#if selectedMethod}
-                {#if methodDetailsLoading}
-                  <div class="rounded border border-outline-variant bg-surface-container-low p-md text-on-surface-variant">Loading Method metadata…</div>
-                {/if}
-                {#if methodDetails}
-                  <div class="space-y-lg">
-                    <div>
-                      <div class="flex flex-wrap items-center gap-sm">
-                        <span class="material-symbols-outlined text-primary">play_circle</span>
-                        <span class="rounded bg-primary/10 px-sm py-xs text-sm font-semibold text-primary">Method Node</span>
-                        <span class="rounded bg-surface-container-highest px-sm py-xs text-sm {methodDetails.Executable && methodDetails.UserExecutable ? 'text-emerald-400' : 'text-tertiary'}">{methodDetails.Executable && methodDetails.UserExecutable ? 'Executable for this session' : methodDetails.Executable ? 'Not executable for this session' : 'Not executable'}</span>
-                      </div>
-                      <p class="mt-md text-on-surface-variant">{methodDetails.Description || 'No description provided.'}</p>
-                    </div>
-
-                    <dl class="grid gap-sm text-sm sm:grid-cols-2">
-                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm"><dt class="label">Object Node</dt><dd class="mt-xs font-semibold">{methodObjectName()}</dd></div>
-                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm"><dt class="label">Method Node</dt><dd class="mt-xs font-semibold">{selectedMethod.DisplayName}</dd></div>
-                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm sm:col-span-2"><dt class="label">Object NodeID</dt><dd class="mt-xs break-all font-mono">{methodDetails.ObjectNodeID}</dd></div>
-                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm sm:col-span-2"><dt class="label">Method NodeID</dt><dd class="mt-xs break-all font-mono">{methodDetails.MethodNodeID}</dd></div>
-                    </dl>
-
-                    <section aria-labelledby="method-input-heading">
-                      <div class="flex items-center justify-between"><h3 id="method-input-heading" class="text-lg font-semibold">Input arguments</h3><span class="font-mono text-xs text-on-surface-variant">{methodDetails.InputArguments.length} ordered</span></div>
-                      {#if methodDetails.InputArguments.length === 0}
-                        <p class="mt-sm text-sm text-on-surface-variant">This Method has no input arguments.</p>
-                      {:else}
-                        <div class="mt-sm space-y-sm">
-                          {#each methodDetails.InputArguments as argument, index}
-                            <label class="block rounded border border-outline-variant bg-surface-container-low p-md">
-                              <span class="flex flex-wrap items-center justify-between gap-sm"><span class="font-semibold">{argument.Name || `Input ${index + 1}`}</span><span class="font-mono text-xs text-primary">{argument.DataType} · {argument.ValueRank}</span></span>
-                              <input class="field mt-sm w-full" aria-label={argument.Name || `Input ${index + 1}`} value={methodInputs[index] || ''} disabled={!argument.Supported || argument.ValueRank !== 'Scalar' || !isSupportedWriteDataType(argument.DataType)} on:input={(event) => updateMethodInput(index, event.currentTarget.value)} on:keydown={(event) => event.key === 'Enter' && event.preventDefault()} placeholder={`Enter ${argument.DataType}`} />
-                              <span class="mt-sm block text-xs text-on-surface-variant">DataType NodeID: {argument.DataTypeID || '—'} · Dimensions: {argument.ArrayDimensions?.length ? argument.ArrayDimensions.join(' × ') : 'none'}</span>
-                              {#if argument.Description}<span class="mt-xs block text-sm text-on-surface-variant">{argument.Description}</span>{/if}
-                            </label>
-                          {/each}
-                        </div>
-                      {/if}
-                    </section>
-
-                    <section aria-labelledby="method-output-heading">
-                      <div class="flex items-center justify-between"><h3 id="method-output-heading" class="text-lg font-semibold">Output arguments</h3><span class="font-mono text-xs text-on-surface-variant">{methodDetails.OutputArguments.length} ordered</span></div>
-                      {#if methodDetails.OutputArguments.length === 0}
-                        <p class="mt-sm text-sm text-on-surface-variant">This Method has no declared output arguments.</p>
-                      {:else}
-                        <ol class="mt-sm space-y-sm">
-                          {#each methodDetails.OutputArguments as argument, index}
-                            <li class="rounded border border-outline-variant bg-surface-container-low p-sm text-sm"><span class="font-semibold">{index + 1}. <span>{argument.Name || `Output ${index + 1}`}</span></span><span class="ml-sm font-mono text-xs text-primary">{argument.DataType} · {argument.ValueRank}</span><p class="mt-xs text-xs text-on-surface-variant">DataType NodeID: {argument.DataTypeID || '—'} · Dimensions: {argument.ArrayDimensions?.length ? argument.ArrayDimensions.join(' × ') : 'none'}</p>{#if argument.Description}<p class="mt-xs text-on-surface-variant">{argument.Description}</p>{/if}</li>
-                          {/each}
-                        </ol>
-                      {/if}
-                    </section>
-
-                    {#if methodDisabledReasons.length > 0}
-                      <ul class="list-disc space-y-xs pl-lg text-sm text-on-surface-variant">
-                        {#each methodDisabledReasons as reason}<li>{reason}</li>{/each}
-                      </ul>
-                    {/if}
-                    <section class="rounded border border-tertiary-container/60 bg-tertiary-container/10 p-md" aria-label="Method call review">
-                      <p class="label">Review Method call</p>
-                      <dl class="mt-sm space-y-xs text-sm">
-                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Saved Connection / Endpoint</dt><dd class="text-right font-mono">{currentConnection || endpointText || 'Current session'}</dd></div>
-                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Object Node</dt><dd class="text-right">{methodObjectName()}</dd></div>
-                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Method Node</dt><dd class="text-right">{selectedMethod.DisplayName}</dd></div>
-                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Object NodeID</dt><dd class="break-all text-right font-mono">{methodDetails.ObjectNodeID}</dd></div>
-                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Method NodeID</dt><dd class="break-all text-right font-mono">{methodDetails.MethodNodeID}</dd></div>
-                        {#each methodDetails.InputArguments as argument, index}<div class="flex justify-between gap-md"><dt class="text-on-surface-variant">{argument.Name || `Input ${index + 1}`}</dt><dd class="break-all text-right font-mono">{methodInputs[index] || '—'}</dd></div>{/each}
-                      </dl>
-                    </section>
-                    <button class="btn-primary w-full" disabled={!canCallMethod} on:click={submitMethodCall}>{methodSubmitting ? 'Calling…' : 'Call Method'}</button>
-
-                    {#if methodCallError}<div class="rounded border border-error-container bg-error-container/20 p-md text-error">{methodCallError}</div>{/if}
-                    {#if methodResult}
-                      <section class="rounded border {methodResult.StatusCode.includes('Good') ? 'border-primary/50 bg-primary/10' : 'border-error-container bg-error-container/20'} p-md" aria-label="Method call result">
-                        <p class="label">StatusCode</p><p class="mt-xs break-all font-mono text-lg">{methodResult.StatusCode}</p>
-                        {#if methodResult.InputArgumentResults.length}<p class="mt-md label">Input argument results</p><ol class="mt-xs list-decimal pl-lg font-mono text-sm">{#each methodResult.InputArgumentResults as status}<li>{status}</li>{/each}</ol>{/if}
-                        <p class="mt-md label">Raw outputs</p>
-                        {#if methodResult.OutputArguments.length}<ol class="mt-xs space-y-xs">{#each methodResult.OutputArguments as output, index}<li class="font-mono text-sm">{index + 1}. <span class="text-primary">{output.DataType}</span> <span>{output.Value}</span></li>{/each}</ol>{:else}<p class="mt-xs text-sm text-on-surface-variant">No output values returned.</p>{/if}
-                      </section>
-                    {/if}
-                  </div>
-                {/if}
-                {#if !methodDetails}
-                  <button class="btn-primary mt-md w-full" disabled>Call Method</button>
-                  {#if methodDisabledReasons.length > 0}<ul class="mt-md list-disc space-y-xs pl-lg text-sm text-on-surface-variant">{#each methodDisabledReasons as reason}<li>{reason}</li>{/each}</ul>{/if}
-                {/if}
+                {#key nodeSelectionKey(selectedMethod)}
+                  <MethodCallPanel
+                    {selectedMethod}
+                    objectNodeName={methodObjectName()}
+                    sessionName={currentConnection || endpointText || 'Current session'}
+                    {connected}
+                    {readOnlyMode}
+                    {addToast}
+                  />
+                {/key}
               {:else if inspection}
                 <div class="grid gap-md lg:grid-cols-3">
                   <div class="panel bg-surface-container-low p-md"><p class="label">Live Value</p><p class="mt-sm font-mono text-2xl text-primary">{inspection.value?.Value || '—'}</p></div>

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { BrowseChildren, ClearVariableNodeInspection, Connect, DeleteSavedConnection, Disconnect, DiscoverEndpoints, GetDiagnosticLogs, GetSavedConnections, GetSessionSafety, GetSessionTrend, GetWatchlist, InspectVariableNode, PickClientCertificate, PickClientPrivateKey, RefreshVariableNodeValue, SaveSavedConnection, SearchAddressSpace, SetReadOnlyMode, UnwatchVariableNode, WatchVariableNode, WriteVariableNodeValue } from '../wailsjs/go/main/App.js'
+  import { BrowseChildren, CallMethod, ClearVariableNodeInspection, Connect, DeleteSavedConnection, Disconnect, DiscoverEndpoints, GetDiagnosticLogs, GetMethodDetails, GetSavedConnections, GetSessionSafety, GetSessionTrend, GetWatchlist, InspectVariableNode, PickClientCertificate, PickClientPrivateKey, RefreshVariableNodeValue, SaveSavedConnection, SearchAddressSpace, SetReadOnlyMode, UnwatchVariableNode, WatchVariableNode, WriteVariableNodeValue } from '../wailsjs/go/main/App.js'
   import { EventsOn } from '../wailsjs/runtime/runtime.js'
   import { getReadmeScreenshotState } from './readmeScreenshots'
 
@@ -17,10 +17,48 @@
   }
 
   type AddressNode = {
+    ParentNodeID: string
     NodeID: string
     DisplayName: string
     BrowseName: string
     NodeClass: string
+  }
+
+  type MethodArgument = {
+    Name: string
+    DataType: string
+    DataTypeID: string
+    ValueRank: string
+    Description: string
+    ArrayDimensions: number[]
+    Supported: boolean
+  }
+
+  type MethodDetails = {
+    ObjectNodeID: string
+    MethodNodeID: string
+    Description: string
+    Executable: boolean
+    UserExecutable: boolean
+    InputArguments: MethodArgument[]
+    OutputArguments: MethodArgument[]
+  }
+
+  type MethodCallResult = {
+    StatusCode: string
+    InputArgumentResults: string[]
+    OutputArguments: Array<{ DataType: string; Value: string }>
+  }
+
+  type MethodCallAvailability = {
+    selectedMethod: AddressNode | null
+    details: MethodDetails | null
+    detailsLoading: boolean
+    detailsError: string
+    inputs: string[]
+    submitting: boolean
+    connected: boolean
+    readOnlyMode: boolean
   }
 
   type AddressSpaceSearchResult = {
@@ -148,7 +186,7 @@
 
   const objectsRoot: TreeNode = {
     key: 'root:i=85',
-    node: { NodeID: 'i=85', DisplayName: 'Objects', BrowseName: 'Objects', NodeClass: 'Object' },
+    node: { ParentNodeID: '', NodeID: 'i=85', DisplayName: 'Objects', BrowseName: 'Objects', NodeClass: 'Object' },
     depth: 0,
     expanded: false,
     childrenLoaded: false,
@@ -197,6 +235,14 @@
   let writeError = ''
   let writeConfirmOpen = false
   let writeConfirmationSnapshot: WriteConfirmationSnapshot | null = null
+  let selectedMethod: AddressNode | null = null
+  let methodDetails: MethodDetails | null = null
+  let methodDetailsLoading = false
+  let methodDetailsError = ''
+  let methodInputs: string[] = []
+  let methodSubmitting = false
+  let methodResult: MethodCallResult | null = null
+  let methodCallError = ''
 
   $: selectedEndpointInfo = endpoints[selectedEndpoint]
   $: selectedSecurityMode = selectedEndpointInfo?.SecurityMode?.replace('MessageSecurityMode', '').trim() || ''
@@ -213,6 +259,8 @@
   $: writeConfirmationInvalidated = isWriteConfirmationInvalidated(inspection, writeConfirmationSnapshot)
   $: writeRangeWarning = writeTargetRangeWarning(inspection, writeTargetValue)
   $: writeStatusWarning = inspection && !inspection.stale && inspection.value?.Status && !inspection.value.Status.includes('Good') ? `Current status is ${inspection.value.Status}; confirm the value is safe to change.` : ''
+  $: methodDisabledReasons = methodCallDisabledReasons({ selectedMethod, details: methodDetails, detailsLoading: methodDetailsLoading, detailsError: methodDetailsError, inputs: methodInputs, submitting: methodSubmitting, connected, readOnlyMode })
+  $: canCallMethod = !!selectedMethod && !!methodDetails && methodDisabledReasons.length === 0
 
   onMount(() => {
     let disposed = false
@@ -265,6 +313,7 @@
   function applySessionSafety(sessionSafety: SessionSafety) {
     connected = sessionSafety.connected
     readOnlyMode = sessionSafety.readOnlyMode
+    if (!sessionSafety.connected) resetMethodState()
   }
 
   function addToast(level: string, message: string) {
@@ -347,6 +396,7 @@
       tree = [{ ...objectsRoot }]
       selectedNodeID = ''
       inspection = null
+      resetMethodState()
       watchlist = []
       sessionTrend = { nodes: [], points: [] }
       focusedTrendNodeID = ''
@@ -448,6 +498,7 @@
       tree = [{ ...objectsRoot }]
       selectedNodeID = ''
       inspection = null
+      resetMethodState()
       watchlist = []
       sessionTrend = { nodes: [], points: [] }
       focusedTrendNodeID = ''
@@ -460,12 +511,12 @@
   }
 
   async function setReadOnlyMode(enabled: boolean) {
-    if (!enabled && !window.confirm('Allow Variable Node Writes?\n\nThis enables Variable Node Writes until you disconnect or turn Read-Only Mode back on. Each write still requires confirmation.')) return
+    if (!enabled && !window.confirm('Allow changes to the OPC UA Server?\n\nThis enables Variable Node Writes and Method calls until you disconnect or turn Read-Only Mode back on. Variable Node Writes still require confirmation.')) return
     try {
       await SetReadOnlyMode(enabled)
       const sessionSafety = await GetSessionSafety()
       applySessionSafety(sessionSafety)
-      addToast('info', enabled ? 'Read-Only Mode enabled' : 'Writes allowed for this session')
+      addToast('info', enabled ? 'Read-Only Mode enabled' : 'Changes allowed for this session')
     } catch (error) {
       addToast('error', String(error))
     }
@@ -503,10 +554,14 @@
   }
 
   async function selectNode(item: TreeNode) {
-    selectedNodeID = item.node.NodeID
+    selectedNodeID = nodeSelectionKey(item.node)
     if (item.node.NodeClass === 'Variable') {
+      resetMethodState()
       await InspectVariableNode(item.node)
+    } else if (item.node.NodeClass === 'Method') {
+      await activateMethod(item.node)
     } else {
+      resetMethodState()
       await ClearVariableNodeInspection()
     }
   }
@@ -539,10 +594,14 @@
   }
 
   async function activateSearchResult(result: AddressSpaceSearchResult) {
-    selectedNodeID = result.node.NodeID
+    selectedNodeID = nodeSelectionKey(result.node)
     if (result.node.NodeClass === 'Variable') {
+      resetMethodState()
       await InspectVariableNode(result.node)
+    } else if (result.node.NodeClass === 'Method') {
+      await activateMethod(result.node)
     } else {
+      resetMethodState()
       await ClearVariableNodeInspection()
     }
   }
@@ -559,7 +618,7 @@
 
   async function activateNode(item: TreeNode) {
     await selectNode(item)
-    if (item.node.NodeClass !== 'Variable') {
+    if (item.node.NodeClass !== 'Variable' && item.node.NodeClass !== 'Method') {
       await toggleNode(item)
     }
   }
@@ -594,6 +653,100 @@
     writeError = ''
     writeConfirmOpen = false
     writeConfirmationSnapshot = null
+  }
+
+  function nodeSelectionKey(node: AddressNode) {
+    return node.NodeClass === 'Method' ? `${node.ParentNodeID || ''}\u0000${node.NodeID}` : node.NodeID
+  }
+
+  function resetMethodState() {
+    selectedMethod = null
+    methodDetails = null
+    methodDetailsLoading = false
+    methodDetailsError = ''
+    methodInputs = []
+    methodSubmitting = false
+    methodResult = null
+    methodCallError = ''
+  }
+
+  async function activateMethod(node: AddressNode) {
+    resetMethodState()
+    resetWriteState()
+    inspection = null
+    selectedMethod = node
+    methodDetailsLoading = true
+    const selectionKey = nodeSelectionKey(node)
+    await ClearVariableNodeInspection()
+    try {
+      const details = await GetMethodDetails({ objectNodeID: node.ParentNodeID || '', methodNodeID: node.NodeID })
+      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) {
+        methodDetails = { ...details, InputArguments: details.InputArguments || [], OutputArguments: details.OutputArguments || [] }
+        methodInputs = methodDetails.InputArguments.map(() => '')
+      }
+    } catch (error) {
+      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) methodDetailsError = String(error)
+    } finally {
+      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) methodDetailsLoading = false
+    }
+  }
+
+  function updateMethodInput(index: number, value: string) {
+    methodInputs = methodInputs.map((current, currentIndex) => currentIndex === index ? value : current)
+    methodResult = null
+    methodCallError = ''
+  }
+
+  function methodCallDisabledReasons(state: MethodCallAvailability) {
+    const reasons: string[] = []
+    if (!state.connected) reasons.push('Connect to an OPC UA Server before calling a Method.')
+    if (state.readOnlyMode) reasons.push('Read-Only Mode is active.')
+    if (state.detailsLoading) reasons.push('Method metadata is loading.')
+    if (state.detailsError) reasons.push(`Method metadata failed to load: ${state.detailsError}`)
+    if (!state.selectedMethod) return reasons
+    if (!state.details && !state.detailsLoading && !state.detailsError) reasons.push('Method metadata is unavailable.')
+    if (!state.details) return reasons
+    if (!state.details.Executable) reasons.push('Method is not executable.')
+    else if (!state.details.UserExecutable) reasons.push('Method is not executable for the current session.')
+    state.details.InputArguments.forEach((argument, index) => {
+      const unsupportedType = !isSupportedWriteDataType(argument.DataType)
+      const unsupportedRank = argument.ValueRank !== 'Scalar'
+      if (!argument.Supported || unsupportedType || unsupportedRank) {
+        const limitations = [unsupportedType ? `DataType ${argument.DataType}` : '', unsupportedRank ? `ValueRank ${argument.ValueRank}` : ''].filter(Boolean).join(' and ')
+        reasons.push(`${argument.Name || `Input ${index + 1}`} uses unsupported ${limitations || 'argument metadata'}.`)
+        return
+      }
+      const error = parseScalarInputError(argument.DataType, state.inputs[index] || '', argument.Name || `Input ${index + 1}`)
+      if (error) reasons.push(error)
+    })
+    if (state.submitting) reasons.push('Method call is in progress.')
+    return reasons
+  }
+
+  async function submitMethodCall() {
+    if (!selectedMethod || !methodDetails || !canCallMethod || methodSubmitting) return
+    const selectionKey = nodeSelectionKey(selectedMethod)
+    methodSubmitting = true
+    methodResult = null
+    methodCallError = ''
+    try {
+      const result = await CallMethod({ objectNodeID: methodDetails.ObjectNodeID, methodNodeID: methodDetails.MethodNodeID, inputArguments: methodInputs })
+      if (!selectedMethod || nodeSelectionKey(selectedMethod) !== selectionKey) return
+      methodResult = { ...result, InputArgumentResults: result.InputArgumentResults || [], OutputArguments: result.OutputArguments || [] }
+      if (result.StatusCode.includes('Good')) addToast('info', `Method call completed: ${result.StatusCode}`)
+      else addToast('error', `Method call returned ${result.StatusCode}`)
+    } catch (error) {
+      if (!selectedMethod || nodeSelectionKey(selectedMethod) !== selectionKey) return
+      methodCallError = `Method call failed: ${String(error)}`
+      addToast('error', methodCallError)
+    } finally {
+      if (selectedMethod && nodeSelectionKey(selectedMethod) === selectionKey) methodSubmitting = false
+    }
+  }
+
+  function methodObjectName() {
+    if (!selectedMethod?.ParentNodeID) return '—'
+    return tree.find(item => item.node.NodeID === selectedMethod?.ParentNodeID)?.node.DisplayName || selectedMethod.ParentNodeID
   }
 
   function openWriteConfirmation() {
@@ -676,25 +829,30 @@
   }
 
   function parseWriteTargetError(dataType: string, target: string) {
+    return parseScalarInputError(dataType, target, 'Target Value')
+  }
+
+  function parseScalarInputError(dataType: string, target: string, label: string) {
     const trimmed = target.trim()
     if (!dataType || !isSupportedWriteDataType(dataType)) return ''
     if (dataType === 'String') return ''
-    if (!trimmed) return 'Enter a Target Value.'
-    if (dataType === 'Boolean') return ['true', 'false', '1', '0', 'on', 'off', 'yes', 'no'].includes(trimmed.toLowerCase()) ? '' : 'Target Value must parse as Boolean.'
+    if (!trimmed) return label === 'Target Value' ? 'Enter a Target Value.' : `Enter a value for ${label}.`
+    if (dataType === 'Boolean') return ['true', 'false', '1', '0', 'on', 'off', 'yes', 'no'].includes(trimmed.toLowerCase()) ? '' : `${label} must parse as Boolean.`
     if (['Float', 'Double'].includes(dataType)) {
       const decimalFloatPattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
       const parsed = Number(trimmed)
-      return decimalFloatPattern.test(trimmed) && Number.isFinite(parsed) ? '' : `Target Value must parse as ${dataType}.`
+      const inRange = Number.isFinite(parsed) && (dataType !== 'Float' || Number.isFinite(Math.fround(parsed)))
+      return decimalFloatPattern.test(trimmed) && inRange ? '' : `${label} must parse as ${dataType}.`
     }
-    if (!/^[+]?\d+$/.test(trimmed) && ['Byte', 'UInt16', 'UInt32', 'UInt64'].includes(dataType)) return `Target Value must be an unsigned plain decimal integer for ${dataType}.`
-    if (!/^[+-]?\d+$/.test(trimmed)) return `Target Value must be a plain decimal integer for ${dataType}.`
+    if (!/^[+]?\d+$/.test(trimmed) && ['Byte', 'UInt16', 'UInt32', 'UInt64'].includes(dataType)) return `${label} must be an unsigned plain decimal integer for ${dataType}.`
+    if (!/^[+-]?\d+$/.test(trimmed)) return `${label} must be a plain decimal integer for ${dataType}.`
     const value = BigInt(trimmed)
     const ranges: Record<string, [bigint, bigint]> = {
       SByte: [BigInt('-128'), BigInt('127')], Int16: [BigInt('-32768'), BigInt('32767')], Int32: [BigInt('-2147483648'), BigInt('2147483647')], Int64: [BigInt('-9223372036854775808'), BigInt('9223372036854775807')],
       Byte: [BigInt('0'), BigInt('255')], UInt16: [BigInt('0'), BigInt('65535')], UInt32: [BigInt('0'), BigInt('4294967295')], UInt64: [BigInt('0'), BigInt('18446744073709551615')]
     }
     const [min, max] = ranges[dataType]
-    return value < min || value > max ? `Target Value is outside ${dataType} range.` : ''
+    return value < min || value > max ? `${label} is outside ${dataType} range.` : ''
   }
 
   function writeTargetRangeWarning(current: Inspection | null, target: string) {
@@ -780,6 +938,7 @@
   function nodeIcon(nodeClass: string) {
     if (nodeClass === 'Variable') return 'monitoring'
     if (nodeClass === 'Object') return 'account_tree'
+    if (nodeClass === 'Method') return 'play_circle'
     return 'schema'
   }
 
@@ -879,9 +1038,9 @@
       </div>
       <div class="flex items-center gap-sm">
         {#if connected}
-          <span class="rounded border border-outline-variant px-sm py-xs text-xs font-bold {readOnlyMode ? 'bg-primary-container text-background' : 'bg-tertiary-container text-background'}">{readOnlyMode ? 'Read-Only Mode' : 'Writes Allowed'}</span>
+          <span class="rounded border border-outline-variant px-sm py-xs text-xs font-bold {readOnlyMode ? 'bg-primary-container text-background' : 'bg-tertiary-container text-background'}">{readOnlyMode ? 'Read-Only Mode' : 'Changes Allowed'}</span>
           {#if readOnlyMode}
-            <button class="btn-secondary" on:click={() => setReadOnlyMode(false)}>Allow writes this session</button>
+            <button class="btn-secondary" on:click={() => setReadOnlyMode(false)}>Allow changes this session</button>
           {:else}
             <button class="btn-secondary" on:click={() => setReadOnlyMode(true)}>Read-Only Mode</button>
           {/if}
@@ -1028,7 +1187,7 @@
           {/if}
         </section>
       {:else if activeTab === 'address-space'}
-        <section class="grid h-full min-h-[600px] gap-lg xl:grid-cols-[minmax(320px,0.85fr)_minmax(380px,1.05fr)_minmax(420px,1.1fr)]">
+        <section class="grid h-full min-h-[600px] gap-lg xl:grid-cols-[minmax(240px,0.8fr)_minmax(280px,0.95fr)_minmax(360px,1.25fr)]">
           <div class="panel flex min-h-0 flex-col overflow-hidden">
             <div class="flex items-center justify-between border-b border-outline-variant p-md">
               <div><p class="label">Address Space</p><h2 class="text-xl font-semibold">Objects</h2></div>
@@ -1040,11 +1199,15 @@
               {:else}
                 {#each visibleTree as item (item.key)}
                   <div class="group flex items-center gap-xs rounded px-sm py-xs hover:bg-surface-container-high" style={`padding-left: ${8 + item.depth * 18}px`}>
-                    <button class="flex h-6 w-6 items-center justify-center rounded hover:bg-surface-container-highest" on:click={() => toggleNode(item)} title="Expand or collapse">
-                      {#if item.loading}<span class="text-xs text-primary">…</span>{:else}<span class="material-symbols-outlined text-[18px]">{item.expanded ? 'expand_more' : 'chevron_right'}</span>{/if}
-                    </button>
-                    <button class="min-w-0 flex-1 truncate rounded px-xs py-xs text-left {selectedNodeID === item.node.NodeID ? 'bg-secondary-container text-on-secondary-container' : 'text-on-surface'}" on:click={() => activateNode(item)}>
-                      <span class="mr-sm font-medium">{item.node.DisplayName}</span><span class="font-mono text-xs text-on-surface-variant">{item.node.NodeClass}</span>
+                    {#if item.node.NodeClass === 'Method'}
+                      <span class="material-symbols-outlined flex h-6 w-6 items-center justify-center text-[18px] text-primary" title="Method Node">play_circle</span>
+                    {:else}
+                      <button class="flex h-6 w-6 items-center justify-center rounded hover:bg-surface-container-highest" on:click={() => toggleNode(item)} title="Expand or collapse">
+                        {#if item.loading}<span class="text-xs text-primary">…</span>{:else}<span class="material-symbols-outlined text-[18px]">{item.expanded ? 'expand_more' : 'chevron_right'}</span>{/if}
+                      </button>
+                    {/if}
+                    <button aria-label={`${item.node.DisplayName} ${item.node.NodeClass}`} class="min-w-0 flex-1 truncate rounded px-xs py-xs text-left {selectedNodeID === nodeSelectionKey(item.node) ? 'bg-secondary-container text-on-secondary-container' : 'text-on-surface'}" on:click={() => activateNode(item)}>
+                      <span class="mr-sm font-medium">{item.node.DisplayName}</span><span class="font-mono text-xs {item.node.NodeClass === 'Method' ? 'text-primary' : 'text-on-surface-variant'}">{item.node.NodeClass}</span>
                     </button>
                   </div>
                   {#if item.error}<div class="ml-lg text-xs text-error">{item.error}</div>{/if}
@@ -1077,9 +1240,9 @@
                 </div>
               {:else}
                 <div class="space-y-md">
-                  {#each searchView.results as result (result.node.NodeID)}
-                    <div role="button" tabindex="0" class="group relative block w-full cursor-pointer overflow-hidden rounded-lg border border-outline-variant bg-surface-container p-md text-left transition-colors hover:border-primary/70 {selectedNodeID === result.node.NodeID ? 'border-primary bg-secondary-container/40' : ''}" on:click={() => activateSearchResult(result)} on:keydown={(event) => event.key === 'Enter' && activateSearchResult(result)}>
-                      <div class="absolute left-0 top-0 bottom-0 w-[2px] bg-primary {selectedNodeID === result.node.NodeID ? 'scale-y-100' : 'scale-y-0 group-hover:scale-y-100'} origin-top transition-transform"></div>
+                  {#each searchView.results as result (nodeSelectionKey(result.node))}
+                    <div role="button" tabindex="0" class="group relative block w-full cursor-pointer overflow-hidden rounded-lg border border-outline-variant bg-surface-container p-md text-left transition-colors hover:border-primary/70 {selectedNodeID === nodeSelectionKey(result.node) ? 'border-primary bg-secondary-container/40' : ''}" on:click={() => activateSearchResult(result)} on:keydown={(event) => event.key === 'Enter' && activateSearchResult(result)}>
+                      <div class="absolute left-0 top-0 bottom-0 w-[2px] bg-primary {selectedNodeID === nodeSelectionKey(result.node) ? 'scale-y-100' : 'scale-y-0 group-hover:scale-y-100'} origin-top transition-transform"></div>
                       <div class="flex items-start justify-between gap-md">
                         <div class="flex min-w-0 gap-sm">
                           <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-outline-variant bg-surface-container-high text-primary">
@@ -1111,7 +1274,7 @@
 
           <div class="panel flex min-h-0 flex-col overflow-hidden">
             <div class="flex items-center justify-between gap-md border-b border-outline-variant p-md">
-              <div class="min-w-0"><p class="label">Variable Node Inspection</p><h2 class="truncate text-xl font-semibold">{inspection?.node?.DisplayName ?? 'No Variable Node selected'}</h2></div>
+              <div class="min-w-0"><p class="label">{selectedMethod ? 'Method Call' : 'Variable Node Inspection'}</p><h2 class="truncate text-xl font-semibold">{selectedMethod?.DisplayName ?? inspection?.node?.DisplayName ?? 'No node selected'}</h2></div>
               {#if inspection}
                 <div class="flex shrink-0 items-center gap-sm">
                   <button class="btn-secondary" on:click={refreshInspectionValue} disabled={refreshingNodeID === inspection.node.NodeID}>{refreshingNodeID === inspection.node.NodeID ? 'Refreshing…' : 'Refresh current value'}</button>
@@ -1124,7 +1287,93 @@
               {/if}
             </div>
             <div class="min-h-0 flex-1 overflow-auto p-lg">
-              {#if inspection}
+              {#if selectedMethod}
+                {#if methodDetailsLoading}
+                  <div class="rounded border border-outline-variant bg-surface-container-low p-md text-on-surface-variant">Loading Method metadata…</div>
+                {/if}
+                {#if methodDetails}
+                  <div class="space-y-lg">
+                    <div>
+                      <div class="flex flex-wrap items-center gap-sm">
+                        <span class="material-symbols-outlined text-primary">play_circle</span>
+                        <span class="rounded bg-primary/10 px-sm py-xs text-sm font-semibold text-primary">Method Node</span>
+                        <span class="rounded bg-surface-container-highest px-sm py-xs text-sm {methodDetails.Executable && methodDetails.UserExecutable ? 'text-emerald-400' : 'text-tertiary'}">{methodDetails.Executable && methodDetails.UserExecutable ? 'Executable for this session' : methodDetails.Executable ? 'Not executable for this session' : 'Not executable'}</span>
+                      </div>
+                      <p class="mt-md text-on-surface-variant">{methodDetails.Description || 'No description provided.'}</p>
+                    </div>
+
+                    <dl class="grid gap-sm text-sm sm:grid-cols-2">
+                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm"><dt class="label">Object Node</dt><dd class="mt-xs font-semibold">{methodObjectName()}</dd></div>
+                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm"><dt class="label">Method Node</dt><dd class="mt-xs font-semibold">{selectedMethod.DisplayName}</dd></div>
+                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm sm:col-span-2"><dt class="label">Object NodeID</dt><dd class="mt-xs break-all font-mono">{methodDetails.ObjectNodeID}</dd></div>
+                      <div class="rounded border border-outline-variant bg-surface-container-low p-sm sm:col-span-2"><dt class="label">Method NodeID</dt><dd class="mt-xs break-all font-mono">{methodDetails.MethodNodeID}</dd></div>
+                    </dl>
+
+                    <section aria-labelledby="method-input-heading">
+                      <div class="flex items-center justify-between"><h3 id="method-input-heading" class="text-lg font-semibold">Input arguments</h3><span class="font-mono text-xs text-on-surface-variant">{methodDetails.InputArguments.length} ordered</span></div>
+                      {#if methodDetails.InputArguments.length === 0}
+                        <p class="mt-sm text-sm text-on-surface-variant">This Method has no input arguments.</p>
+                      {:else}
+                        <div class="mt-sm space-y-sm">
+                          {#each methodDetails.InputArguments as argument, index}
+                            <label class="block rounded border border-outline-variant bg-surface-container-low p-md">
+                              <span class="flex flex-wrap items-center justify-between gap-sm"><span class="font-semibold">{argument.Name || `Input ${index + 1}`}</span><span class="font-mono text-xs text-primary">{argument.DataType} · {argument.ValueRank}</span></span>
+                              <input class="field mt-sm w-full" aria-label={argument.Name || `Input ${index + 1}`} value={methodInputs[index] || ''} disabled={!argument.Supported || argument.ValueRank !== 'Scalar' || !isSupportedWriteDataType(argument.DataType)} on:input={(event) => updateMethodInput(index, event.currentTarget.value)} on:keydown={(event) => event.key === 'Enter' && event.preventDefault()} placeholder={`Enter ${argument.DataType}`} />
+                              <span class="mt-sm block text-xs text-on-surface-variant">DataType NodeID: {argument.DataTypeID || '—'} · Dimensions: {argument.ArrayDimensions?.length ? argument.ArrayDimensions.join(' × ') : 'none'}</span>
+                              {#if argument.Description}<span class="mt-xs block text-sm text-on-surface-variant">{argument.Description}</span>{/if}
+                            </label>
+                          {/each}
+                        </div>
+                      {/if}
+                    </section>
+
+                    <section aria-labelledby="method-output-heading">
+                      <div class="flex items-center justify-between"><h3 id="method-output-heading" class="text-lg font-semibold">Output arguments</h3><span class="font-mono text-xs text-on-surface-variant">{methodDetails.OutputArguments.length} ordered</span></div>
+                      {#if methodDetails.OutputArguments.length === 0}
+                        <p class="mt-sm text-sm text-on-surface-variant">This Method has no declared output arguments.</p>
+                      {:else}
+                        <ol class="mt-sm space-y-sm">
+                          {#each methodDetails.OutputArguments as argument, index}
+                            <li class="rounded border border-outline-variant bg-surface-container-low p-sm text-sm"><span class="font-semibold">{index + 1}. <span>{argument.Name || `Output ${index + 1}`}</span></span><span class="ml-sm font-mono text-xs text-primary">{argument.DataType} · {argument.ValueRank}</span><p class="mt-xs text-xs text-on-surface-variant">DataType NodeID: {argument.DataTypeID || '—'} · Dimensions: {argument.ArrayDimensions?.length ? argument.ArrayDimensions.join(' × ') : 'none'}</p>{#if argument.Description}<p class="mt-xs text-on-surface-variant">{argument.Description}</p>{/if}</li>
+                          {/each}
+                        </ol>
+                      {/if}
+                    </section>
+
+                    {#if methodDisabledReasons.length > 0}
+                      <ul class="list-disc space-y-xs pl-lg text-sm text-on-surface-variant">
+                        {#each methodDisabledReasons as reason}<li>{reason}</li>{/each}
+                      </ul>
+                    {/if}
+                    <section class="rounded border border-tertiary-container/60 bg-tertiary-container/10 p-md" aria-label="Method call review">
+                      <p class="label">Review Method call</p>
+                      <dl class="mt-sm space-y-xs text-sm">
+                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Saved Connection / Endpoint</dt><dd class="text-right font-mono">{currentConnection || endpointText || 'Current session'}</dd></div>
+                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Object Node</dt><dd class="text-right">{methodObjectName()}</dd></div>
+                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Method Node</dt><dd class="text-right">{selectedMethod.DisplayName}</dd></div>
+                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Object NodeID</dt><dd class="break-all text-right font-mono">{methodDetails.ObjectNodeID}</dd></div>
+                        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Method NodeID</dt><dd class="break-all text-right font-mono">{methodDetails.MethodNodeID}</dd></div>
+                        {#each methodDetails.InputArguments as argument, index}<div class="flex justify-between gap-md"><dt class="text-on-surface-variant">{argument.Name || `Input ${index + 1}`}</dt><dd class="break-all text-right font-mono">{methodInputs[index] || '—'}</dd></div>{/each}
+                      </dl>
+                    </section>
+                    <button class="btn-primary w-full" disabled={!canCallMethod} on:click={submitMethodCall}>{methodSubmitting ? 'Calling…' : 'Call Method'}</button>
+
+                    {#if methodCallError}<div class="rounded border border-error-container bg-error-container/20 p-md text-error">{methodCallError}</div>{/if}
+                    {#if methodResult}
+                      <section class="rounded border {methodResult.StatusCode.includes('Good') ? 'border-primary/50 bg-primary/10' : 'border-error-container bg-error-container/20'} p-md" aria-label="Method call result">
+                        <p class="label">StatusCode</p><p class="mt-xs break-all font-mono text-lg">{methodResult.StatusCode}</p>
+                        {#if methodResult.InputArgumentResults.length}<p class="mt-md label">Input argument results</p><ol class="mt-xs list-decimal pl-lg font-mono text-sm">{#each methodResult.InputArgumentResults as status}<li>{status}</li>{/each}</ol>{/if}
+                        <p class="mt-md label">Raw outputs</p>
+                        {#if methodResult.OutputArguments.length}<ol class="mt-xs space-y-xs">{#each methodResult.OutputArguments as output, index}<li class="font-mono text-sm">{index + 1}. <span class="text-primary">{output.DataType}</span> <span>{output.Value}</span></li>{/each}</ol>{:else}<p class="mt-xs text-sm text-on-surface-variant">No output values returned.</p>{/if}
+                      </section>
+                    {/if}
+                  </div>
+                {/if}
+                {#if !methodDetails}
+                  <button class="btn-primary mt-md w-full" disabled>Call Method</button>
+                  {#if methodDisabledReasons.length > 0}<ul class="mt-md list-disc space-y-xs pl-lg text-sm text-on-surface-variant">{#each methodDisabledReasons as reason}<li>{reason}</li>{/each}</ul>{/if}
+                {/if}
+              {:else if inspection}
                 <div class="grid gap-md lg:grid-cols-3">
                   <div class="panel bg-surface-container-low p-md"><p class="label">Live Value</p><p class="mt-sm font-mono text-2xl text-primary">{inspection.value?.Value || '—'}</p></div>
                   <div class="panel bg-surface-container-low p-md"><p class="label">Status</p><p class="mt-sm font-mono text-sm {inspection.stale ? 'text-tertiary' : 'text-emerald-400'}">{inspection.stale ? 'Stale' : inspection.value?.Status || 'Waiting'}</p></div>
@@ -1141,7 +1390,7 @@
                       <h3 class="mt-xs text-lg font-semibold">Write value</h3>
                       <p class="mt-xs text-sm text-on-surface-variant">Available only from Variable Node Inspection. Every write requires confirmation and cannot be submitted with Enter.</p>
                     </div>
-                    <span class="rounded px-sm py-xs text-xs font-bold {readOnlyMode ? 'bg-primary-container text-background' : 'bg-tertiary-container text-background'}">{readOnlyMode ? 'Read-Only Mode' : 'Writes Allowed'}</span>
+                    <span class="rounded px-sm py-xs text-xs font-bold {readOnlyMode ? 'bg-primary-container text-background' : 'bg-tertiary-container text-background'}">{readOnlyMode ? 'Read-Only Mode' : 'Changes Allowed'}</span>
                   </div>
                   <div class="mt-md grid gap-sm lg:grid-cols-[1fr_auto]">
                     <label class="space-y-xs">
@@ -1190,7 +1439,7 @@
                   </div>
                 </div>
               {:else}
-                <div class="flex h-full items-center justify-center text-on-surface-variant">Select a Variable Node from the Address Space to inspect its Live Value and metadata.</div>
+                <div class="flex h-full items-center justify-center text-center text-on-surface-variant">Select a Variable Node or Method Node from the Address Space to inspect it.</div>
               {/if}
             </div>
           </div>

--- a/frontend/src/MethodCallPanel.svelte
+++ b/frontend/src/MethodCallPanel.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+  import { onDestroy, onMount } from 'svelte'
+  import { CallMethod, GetMethodDetails } from '../wailsjs/go/main/App.js'
+  import { isSupportedScalarDataType, parseScalarInputError } from './scalarInput'
+
+  type AddressNode = { ParentNodeID: string; NodeID: string; DisplayName: string; BrowseName: string; NodeClass: string }
+  type MethodArgument = { Name: string; DataType: string; DataTypeID: string; ValueRank: string; Description: string; ArrayDimensions: number[]; Supported: boolean }
+  type MethodDetails = { ObjectNodeID: string; MethodNodeID: string; Description: string; Executable: boolean; UserExecutable: boolean; InputArguments: MethodArgument[]; OutputArguments: MethodArgument[] }
+  type MethodCallResult = { StatusCode: string; InputArgumentResults: string[]; OutputArguments: Array<{ DataType: string; Value: string }> }
+  type MethodCallAvailability = { connected: boolean; readOnlyMode: boolean; details: MethodDetails | null; detailsLoading: boolean; detailsError: string; inputs: string[]; submitting: boolean }
+
+  export let selectedMethod: AddressNode
+  export let objectNodeName: string
+  export let sessionName: string
+  export let connected: boolean
+  export let readOnlyMode: boolean
+  export let addToast: (level: string, message: string) => void
+
+  let details: MethodDetails | null = null
+  let detailsLoading = true
+  let detailsError = ''
+  let inputs: string[] = []
+  let submitting = false
+  let result: MethodCallResult | null = null
+  let callError = ''
+  let disposed = false
+
+  $: disabledReasons = methodCallDisabledReasons({ connected, readOnlyMode, details, detailsLoading, detailsError, inputs, submitting })
+  $: canCall = !!details && disabledReasons.length === 0
+
+  onMount(async () => {
+    try {
+      const loaded = await GetMethodDetails({ objectNodeID: selectedMethod.ParentNodeID || '', methodNodeID: selectedMethod.NodeID })
+      if (disposed) return
+      details = { ...loaded, InputArguments: loaded.InputArguments || [], OutputArguments: loaded.OutputArguments || [] }
+      inputs = details.InputArguments.map(() => '')
+    } catch (error) {
+      if (!disposed) detailsError = String(error)
+    } finally {
+      if (!disposed) detailsLoading = false
+    }
+  })
+
+  onDestroy(() => { disposed = true })
+
+  function updateInput(index: number, value: string) {
+    inputs = inputs.map((current, currentIndex) => currentIndex === index ? value : current)
+    result = null
+    callError = ''
+  }
+
+  function methodCallDisabledReasons(state: MethodCallAvailability) {
+    const reasons: string[] = []
+    if (!state.connected) reasons.push('Connect to an OPC UA Server before calling a Method.')
+    if (state.readOnlyMode) reasons.push('Read-Only Mode is active.')
+    if (state.detailsLoading) reasons.push('Method metadata is loading.')
+    if (state.detailsError) reasons.push(`Method metadata failed to load: ${state.detailsError}`)
+    if (!state.details && !state.detailsLoading && !state.detailsError) reasons.push('Method metadata is unavailable.')
+    if (!state.details) return reasons
+    if (!state.details.Executable) reasons.push('Method is not executable.')
+    else if (!state.details.UserExecutable) reasons.push('Method is not executable for the current session.')
+    state.details.InputArguments.forEach((argument, index) => {
+      const unsupportedType = !isSupportedScalarDataType(argument.DataType)
+      const unsupportedRank = argument.ValueRank !== 'Scalar'
+      if (!argument.Supported || unsupportedType || unsupportedRank) {
+        const limitations = [unsupportedType ? `DataType ${argument.DataType}` : '', unsupportedRank ? `ValueRank ${argument.ValueRank}` : ''].filter(Boolean).join(' and ')
+        reasons.push(`${argument.Name || `Input ${index + 1}`} uses unsupported ${limitations || 'argument metadata'}.`)
+        return
+      }
+      const error = parseScalarInputError(argument.DataType, state.inputs[index] || '', argument.Name || `Input ${index + 1}`)
+      if (error) reasons.push(error)
+    })
+    if (state.submitting) reasons.push('Method call is in progress.')
+    return reasons
+  }
+
+  async function submit() {
+    if (!details || !canCall || submitting || !connected) return
+    submitting = true
+    result = null
+    callError = ''
+    try {
+      const response = await CallMethod({ objectNodeID: details.ObjectNodeID, methodNodeID: details.MethodNodeID, inputArguments: inputs })
+      if (disposed) return
+      result = { ...response, InputArgumentResults: response.InputArgumentResults || [], OutputArguments: response.OutputArguments || [] }
+      if (response.StatusCode.includes('Good')) addToast('info', `Method call completed: ${response.StatusCode}`)
+      else addToast('error', `Method call returned ${response.StatusCode}`)
+    } catch (error) {
+      if (disposed) return
+      callError = `Method call failed: ${String(error)}`
+      addToast('error', callError)
+    } finally {
+      if (!disposed) submitting = false
+    }
+  }
+</script>
+
+{#if detailsLoading}
+  <div class="rounded border border-outline-variant bg-surface-container-low p-md text-on-surface-variant">Loading Method metadata…</div>
+{/if}
+{#if details}
+  <div class="space-y-lg">
+    <div>
+      <div class="flex flex-wrap items-center gap-sm">
+        <span class="material-symbols-outlined text-primary">play_circle</span>
+        <span class="rounded bg-primary/10 px-sm py-xs text-sm font-semibold text-primary">Method Node</span>
+        <span class="rounded bg-surface-container-highest px-sm py-xs text-sm {details.Executable && details.UserExecutable ? 'text-emerald-400' : 'text-tertiary'}">{details.Executable && details.UserExecutable ? 'Executable for this session' : details.Executable ? 'Not executable for this session' : 'Not executable'}</span>
+      </div>
+      <p class="mt-md text-on-surface-variant">{details.Description || 'No description provided.'}</p>
+    </div>
+
+    <dl class="grid gap-sm text-sm sm:grid-cols-2">
+      <div class="rounded border border-outline-variant bg-surface-container-low p-sm"><dt class="label">Object Node</dt><dd class="mt-xs font-semibold">{objectNodeName}</dd></div>
+      <div class="rounded border border-outline-variant bg-surface-container-low p-sm"><dt class="label">Method Node</dt><dd class="mt-xs font-semibold">{selectedMethod.DisplayName}</dd></div>
+      <div class="rounded border border-outline-variant bg-surface-container-low p-sm sm:col-span-2"><dt class="label">Object NodeID</dt><dd class="mt-xs break-all font-mono">{details.ObjectNodeID}</dd></div>
+      <div class="rounded border border-outline-variant bg-surface-container-low p-sm sm:col-span-2"><dt class="label">Method NodeID</dt><dd class="mt-xs break-all font-mono">{details.MethodNodeID}</dd></div>
+    </dl>
+
+    <section aria-labelledby="method-input-heading">
+      <div class="flex items-center justify-between"><h3 id="method-input-heading" class="text-lg font-semibold">Input arguments</h3><span class="font-mono text-xs text-on-surface-variant">{details.InputArguments.length} ordered</span></div>
+      {#if details.InputArguments.length === 0}
+        <p class="mt-sm text-sm text-on-surface-variant">This Method has no input arguments.</p>
+      {:else}
+        <div class="mt-sm space-y-sm">
+          {#each details.InputArguments as argument, index}
+            <label class="block rounded border border-outline-variant bg-surface-container-low p-md">
+              <span class="flex flex-wrap items-center justify-between gap-sm"><span class="font-semibold">{argument.Name || `Input ${index + 1}`}</span><span class="font-mono text-xs text-primary">{argument.DataType} · {argument.ValueRank}</span></span>
+              <input class="field mt-sm w-full" aria-label={argument.Name || `Input ${index + 1}`} value={inputs[index] || ''} disabled={!argument.Supported || argument.ValueRank !== 'Scalar' || !isSupportedScalarDataType(argument.DataType)} on:input={(event) => updateInput(index, event.currentTarget.value)} on:keydown={(event) => event.key === 'Enter' && event.preventDefault()} placeholder={`Enter ${argument.DataType}`} />
+              <span class="mt-sm block text-xs text-on-surface-variant">DataType NodeID: {argument.DataTypeID || '—'} · Dimensions: {argument.ArrayDimensions?.length ? argument.ArrayDimensions.join(' × ') : 'none'}</span>
+              {#if argument.Description}<span class="mt-xs block text-sm text-on-surface-variant">{argument.Description}</span>{/if}
+            </label>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    <section aria-labelledby="method-output-heading">
+      <div class="flex items-center justify-between"><h3 id="method-output-heading" class="text-lg font-semibold">Output arguments</h3><span class="font-mono text-xs text-on-surface-variant">{details.OutputArguments.length} ordered</span></div>
+      {#if details.OutputArguments.length === 0}
+        <p class="mt-sm text-sm text-on-surface-variant">This Method has no declared output arguments.</p>
+      {:else}
+        <ol class="mt-sm space-y-sm">
+          {#each details.OutputArguments as argument, index}
+            <li class="rounded border border-outline-variant bg-surface-container-low p-sm text-sm"><span class="font-semibold">{index + 1}. <span>{argument.Name || `Output ${index + 1}`}</span></span><span class="ml-sm font-mono text-xs text-primary">{argument.DataType} · {argument.ValueRank}</span><p class="mt-xs text-xs text-on-surface-variant">DataType NodeID: {argument.DataTypeID || '—'} · Dimensions: {argument.ArrayDimensions?.length ? argument.ArrayDimensions.join(' × ') : 'none'}</p>{#if argument.Description}<p class="mt-xs text-on-surface-variant">{argument.Description}</p>{/if}</li>
+          {/each}
+        </ol>
+      {/if}
+    </section>
+
+    {#if disabledReasons.length > 0}
+      <ul class="list-disc space-y-xs pl-lg text-sm text-on-surface-variant">{#each disabledReasons as reason}<li>{reason}</li>{/each}</ul>
+    {/if}
+    <section class="rounded border border-tertiary-container/60 bg-tertiary-container/10 p-md" aria-label="Method call review">
+      <p class="label">Review Method call</p>
+      <dl class="mt-sm space-y-xs text-sm">
+        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Saved Connection / Endpoint</dt><dd class="text-right font-mono">{sessionName}</dd></div>
+        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Object Node</dt><dd class="text-right">{objectNodeName}</dd></div>
+        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Method Node</dt><dd class="text-right">{selectedMethod.DisplayName}</dd></div>
+        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Object NodeID</dt><dd class="break-all text-right font-mono">{details.ObjectNodeID}</dd></div>
+        <div class="flex justify-between gap-md"><dt class="text-on-surface-variant">Method NodeID</dt><dd class="break-all text-right font-mono">{details.MethodNodeID}</dd></div>
+        {#each details.InputArguments as argument, index}<div class="flex justify-between gap-md"><dt class="text-on-surface-variant">{argument.Name || `Input ${index + 1}`}</dt><dd class="break-all text-right font-mono">{inputs[index] || '—'}</dd></div>{/each}
+      </dl>
+    </section>
+    <button class="btn-primary w-full" disabled={!canCall} on:click={submit}>{submitting ? 'Calling…' : 'Call Method'}</button>
+
+    {#if callError}<div class="rounded border border-error-container bg-error-container/20 p-md text-error">{callError}</div>{/if}
+    {#if result}
+      <section class="rounded border {result.StatusCode.includes('Good') ? 'border-primary/50 bg-primary/10' : 'border-error-container bg-error-container/20'} p-md" aria-label="Method call result">
+        <p class="label">StatusCode</p><p class="mt-xs break-all font-mono text-lg">{result.StatusCode}</p>
+        {#if result.InputArgumentResults.length}<p class="mt-md label">Input argument results</p><ol class="mt-xs list-decimal pl-lg font-mono text-sm">{#each result.InputArgumentResults as status}<li>{status}</li>{/each}</ol>{/if}
+        <p class="mt-md label">Raw outputs</p>
+        {#if result.OutputArguments.length}<ol class="mt-xs space-y-xs">{#each result.OutputArguments as output, index}<li class="font-mono text-sm">{index + 1}. <span class="text-primary">{output.DataType}</span> <span>{output.Value}</span></li>{/each}</ol>{:else}<p class="mt-xs text-sm text-on-surface-variant">No output values returned.</p>{/if}
+      </section>
+    {/if}
+  </div>
+{/if}
+{#if !details}
+  <button class="btn-primary mt-md w-full" disabled>Call Method</button>
+  {#if disabledReasons.length > 0}<ul class="mt-md list-disc space-y-xs pl-lg text-sm text-on-surface-variant">{#each disabledReasons as reason}<li>{reason}</li>{/each}</ul>{/if}
+{/if}

--- a/frontend/src/readmeScreenshots.ts
+++ b/frontend/src/readmeScreenshots.ts
@@ -1,6 +1,7 @@
 type Tab = 'connections' | 'address-space' | 'watchlist' | 'session-trend' | 'logs'
 
 type AddressNode = {
+  ParentNodeID?: string
   NodeID: string
   DisplayName: string
   BrowseName: string
@@ -18,7 +19,9 @@ const nodes = {
   temp: { NodeID: 'ns=2;s=Plant.Line1.Filler.Temperature', DisplayName: 'Filler Temperature', BrowseName: '2:FillerTemperature', NodeClass: 'Variable' },
   pressure: { NodeID: 'ns=2;s=Plant.Line1.Filler.Pressure', DisplayName: 'Bowl Pressure', BrowseName: '2:BowlPressure', NodeClass: 'Variable' },
   speed: { NodeID: 'ns=2;s=Plant.Line1.Conveyor.Speed', DisplayName: 'Conveyor Speed', BrowseName: '2:ConveyorSpeed', NodeClass: 'Variable' },
-  rejectCount: { NodeID: 'ns=2;s=Plant.Line1.RejectCount', DisplayName: 'Reject Count', BrowseName: '2:RejectCount', NodeClass: 'Variable' }
+  rejectCount: { NodeID: 'ns=2;s=Plant.Line1.RejectCount', DisplayName: 'Reject Count', BrowseName: '2:RejectCount', NodeClass: 'Variable' },
+  methods: { ParentNodeID: 'i=85', NodeID: 'ns=3;s=Demo.CTT.Methods', DisplayName: 'Methods', BrowseName: '3:Methods', NodeClass: 'Object' },
+  methodIO: { ParentNodeID: 'ns=3;s=Demo.CTT.Methods', NodeID: 'ns=3;s=Demo.CTT.Methods.MethodIO', DisplayName: 'MethodIO', BrowseName: '3:MethodIO', NodeClass: 'Method' }
 } satisfies Record<string, AddressNode>
 
 const tree = [
@@ -29,7 +32,9 @@ const tree = [
   { key: nodes.pressure.NodeID, node: nodes.pressure, depth: 3, expanded: false, childrenLoaded: false, loading: false, error: '' },
   { key: nodes.conveyor.NodeID, node: nodes.conveyor, depth: 2, expanded: true, childrenLoaded: true, loading: false, error: '' },
   { key: nodes.speed.NodeID, node: nodes.speed, depth: 3, expanded: false, childrenLoaded: false, loading: false, error: '' },
-  { key: nodes.rejectCount.NodeID, node: nodes.rejectCount, depth: 2, expanded: false, childrenLoaded: false, loading: false, error: '' }
+  { key: nodes.rejectCount.NodeID, node: nodes.rejectCount, depth: 2, expanded: false, childrenLoaded: false, loading: false, error: '' },
+  { key: nodes.methods.NodeID, node: nodes.methods, depth: 1, expanded: true, childrenLoaded: true, loading: false, error: '' },
+  { key: nodes.methodIO.NodeID, node: nodes.methodIO, depth: 2, expanded: false, childrenLoaded: true, loading: false, error: '' }
 ]
 
 const inspection = {
@@ -129,6 +134,14 @@ const searchResults = [nodes.temp, nodes.pressure, nodes.speed].map((node, index
   score: 100 - index * 7
 }))
 
+const methodSearchResults = [{
+  node: nodes.methodIO,
+  matchKind: 'DisplayName',
+  matchText: 'MethodIO',
+  source: 'Browsed Address Space metadata',
+  score: 100
+}]
+
 const sessionTrend = {
   nodes: [
     { node: nodes.temp, latestValue: '83.7 °C', status: 'Good', pointCount: 12 },
@@ -190,7 +203,7 @@ export function getReadmeScreenshotState(): ReadmeScreenshotState | null {
   return {
     activeTab: tabByRequest[requested] || 'address-space',
     connected: true,
-    readOnlyMode: !requested.startsWith('write-') || requested === 'write-read-only',
+    readOnlyMode: requested === 'method-call-read-only' || (!requested.startsWith('write-') && !requested.startsWith('method-call')) || requested === 'write-read-only',
     currentConnection: 'Control Gateway',
     tree,
     selectedNodeID: nodes.temp.NodeID,
@@ -202,7 +215,9 @@ export function getReadmeScreenshotState(): ReadmeScreenshotState | null {
     sessionTrend,
     focusedTrendNodeID: nodes.temp.NodeID,
     searchQuery: requested === 'connections' ? '' : 'filler',
-    searchView: { query: 'filler', results: searchResults, status: '3 Search Results found in browsed Address Space metadata.' },
+    searchView: requested.startsWith('method-call')
+      ? { query: 'method', results: methodSearchResults as typeof searchResults, status: '1 Search Result found in browsed Address Space metadata.' }
+      : { query: 'filler', results: searchResults, status: '3 Search Results found in browsed Address Space metadata.' },
     savedConnections,
     endpoints: [
       { URL: 'opc.tcp://192.168.10.42:4840', SecurityPolicy: 'Basic256Sha256', SecurityMode: 'SignAndEncrypt', SecurityLevel: 3, UserTokenTypes: ['Anonymous', 'UserName'], ServerThumbprint: '8A:91:4F:2C:67:12:EB:44' },

--- a/frontend/src/readmeScreenshots.ts
+++ b/frontend/src/readmeScreenshots.ts
@@ -210,7 +210,7 @@ export function getReadmeScreenshotState(): ReadmeScreenshotState | null {
     inspection: inspectionForRequest(requested),
     confirmationInspectionUpdate: requested === 'write-confirmation-live-value-change' ? changedInspection : null,
     logs: [],
-    receiveRuntimeEvents: requested === 'write-feedback-events',
+    receiveRuntimeEvents: requested === 'write-feedback-events' || requested === 'method-call-events',
     watchlist,
     sessionTrend,
     focusedTrendNodeID: nodes.temp.NodeID,

--- a/frontend/src/scalarInput.ts
+++ b/frontend/src/scalarInput.ts
@@ -1,0 +1,32 @@
+const supportedScalarDataTypes = ['Boolean', 'SByte', 'Int16', 'Int32', 'Int64', 'Byte', 'UInt16', 'UInt32', 'UInt64', 'Float', 'Double', 'String']
+const decimalFloatPattern = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/
+
+export function isSupportedScalarDataType(dataType: string) {
+  return supportedScalarDataTypes.includes(dataType.trim())
+}
+
+export function parseScalarInputError(dataType: string, target: string, label: string) {
+  const trimmed = target.trim()
+  if (!dataType || !isSupportedScalarDataType(dataType)) return ''
+  if (dataType === 'String') return ''
+  if (!trimmed) return label === 'Target Value' ? 'Enter a Target Value.' : `Enter a value for ${label}.`
+  if (dataType === 'Boolean') return ['true', 'false', '1', '0', 'on', 'off', 'yes', 'no'].includes(trimmed.toLowerCase()) ? '' : `${label} must parse as Boolean.`
+  if (dataType === 'Float' || dataType === 'Double') {
+    if (!decimalFloatPattern.test(trimmed)) return `${label} must parse as ${dataType}.`
+    const parsed = Number(trimmed)
+    const significand = trimmed.split(/[eE]/, 1)[0]
+    const representsNonZero = /[1-9]/.test(significand)
+    const represented = dataType === 'Float' ? Math.fround(parsed) : parsed
+    const inRange = Number.isFinite(represented) && !(representsNonZero && represented === 0)
+    return inRange ? '' : `${label} must parse as ${dataType}.`
+  }
+  if (!/^[+]?\d+$/.test(trimmed) && ['Byte', 'UInt16', 'UInt32', 'UInt64'].includes(dataType)) return `${label} must be an unsigned plain decimal integer for ${dataType}.`
+  if (!/^[+-]?\d+$/.test(trimmed)) return `${label} must be a plain decimal integer for ${dataType}.`
+  const value = BigInt(trimmed)
+  const ranges: Record<string, [bigint, bigint]> = {
+    SByte: [BigInt('-128'), BigInt('127')], Int16: [BigInt('-32768'), BigInt('32767')], Int32: [BigInt('-2147483648'), BigInt('2147483647')], Int64: [BigInt('-9223372036854775808'), BigInt('9223372036854775807')],
+    Byte: [BigInt('0'), BigInt('255')], UInt16: [BigInt('0'), BigInt('65535')], UInt32: [BigInt('0'), BigInt('4294967295')], UInt64: [BigInt('0'), BigInt('18446744073709551615')]
+  }
+  const [min, max] = ranges[dataType]
+  return value < min || value > max ? `${label} is outside ${dataType} range.` : ''
+}

--- a/frontend/tests/ui/method-call.spec.ts
+++ b/frontend/tests/ui/method-call.spec.ts
@@ -104,6 +104,37 @@ test('invalid and unsupported arguments show visible disabled reasons', async ({
   await expect(page.getByRole('button', { name: 'Call Method' })).toBeDisabled()
 })
 
+test('Float and Double arguments accept valid forms and reject overflow and underflow', async ({ page }) => {
+  await stubMethodAPI(page, { details: {
+    ...methodDetails,
+    InputArguments: [
+      { ...methodDetails.InputArguments[0], Name: 'FloatValue', DataType: 'Float', DataTypeID: 'i=10' },
+      { ...methodDetails.InputArguments[1], Name: 'DoubleValue', DataType: 'Double', DataTypeID: 'i=11' }
+    ]
+  } })
+  await openMethod(page)
+
+  const callMethod = page.getByRole('button', { name: 'Call Method' })
+  await page.getByLabel('FloatValue').fill('1.25e-3')
+  await page.getByLabel('DoubleValue').fill('-.5E+2')
+  await expect(callMethod).toBeEnabled()
+
+  await page.getByLabel('FloatValue').fill('1e50')
+  await expect(page.getByText('FloatValue must parse as Float.', { exact: true })).toBeVisible()
+  await expect(callMethod).toBeDisabled()
+  await page.getByLabel('FloatValue').fill('1e-50')
+  await expect(page.getByText('FloatValue must parse as Float.', { exact: true })).toBeVisible()
+  await expect(callMethod).toBeDisabled()
+
+  await page.getByLabel('FloatValue').fill('3.5')
+  await page.getByLabel('DoubleValue').fill('1e999')
+  await expect(page.getByText('DoubleValue must parse as Double.', { exact: true })).toBeVisible()
+  await expect(callMethod).toBeDisabled()
+  await page.getByLabel('DoubleValue').fill('1e-999')
+  await expect(page.getByText('DoubleValue must parse as Double.', { exact: true })).toBeVisible()
+  await expect(callMethod).toBeDisabled()
+})
+
 test('loading, failed metadata, and non-executable states explain why calling is blocked', async ({ page }) => {
   await page.addInitScript(() => {
     const testWindow = window as typeof window & { go: unknown }
@@ -197,12 +228,57 @@ test('non-Good and transport failures remain visible inline with concise toasts'
   await expect(page.getByText('Method call failed: Error: transport unavailable', { exact: true }).first()).toBeVisible()
 })
 
+test('a lost session keeps the Method visible but blocks execution at the Wails seam', async ({ page }) => {
+  await page.addInitScript(({ details }) => {
+    type EventCallback = (...args: unknown[]) => void
+    const listeners = new Map<string, Set<EventCallback>>()
+    const testWindow = window as typeof window & { go: unknown; runtime: unknown; methodCalls: unknown[]; loseSession: () => void }
+    testWindow.methodCalls = []
+    const runtime = {
+      EventsOnMultiple(eventName: string, callback: EventCallback) {
+        const eventListeners = listeners.get(eventName) ?? new Set<EventCallback>()
+        eventListeners.add(callback)
+        listeners.set(eventName, eventListeners)
+        return () => eventListeners.delete(callback)
+      },
+      EventsEmit(eventName: string, ...args: unknown[]) {
+        listeners.get(eventName)?.forEach(callback => callback(...args))
+      }
+    }
+    testWindow.runtime = runtime
+    testWindow.loseSession = () => runtime.EventsEmit('session-safety-updated', { connected: false, readOnlyMode: false })
+    testWindow.go = { main: { App: {
+      GetDiagnosticLogs: () => Promise.resolve([]),
+      GetSavedConnections: () => Promise.resolve([]),
+      GetSessionSafety: () => Promise.resolve({ connected: true, readOnlyMode: false }),
+      GetSessionTrend: () => Promise.resolve({ nodes: [], points: [] }),
+      GetWatchlist: () => Promise.resolve([]),
+      GetMethodDetails: () => Promise.resolve(details),
+      CallMethod: (request: unknown) => { testWindow.methodCalls.push(request); return Promise.resolve({ StatusCode: 'StatusGood', InputArgumentResults: [], OutputArguments: [] }) },
+      ClearVariableNodeInspection: () => Promise.resolve()
+    } } }
+  }, { details: methodDetails })
+  await openMethod(page, 'tree', 'method-call-events')
+  await enterMethodInputs(page)
+  await page.evaluate(() => (window as typeof window & { loseSession: () => void }).loseSession())
+
+  await expect(page.getByRole('heading', { name: 'MethodIO', level: 2 })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Call Method' })).toBeDisabled()
+  await expect(page.getByText('Connect to an OPC UA Server before calling a Method.', { exact: true })).toBeVisible()
+  await expect(page.getByText('Read-Only Mode is active.', { exact: true })).toHaveCount(0)
+  await expect.poll(() => page.evaluate(() => (window as typeof window & { methodCalls: unknown[] }).methodCalls)).toEqual([])
+})
+
 test('disconnect clears the Method Call panel and transient inputs', async ({ page }) => {
   await stubMethodAPI(page)
   await openMethod(page)
-  await page.getByLabel('Summand1').fill('20')
+  await enterMethodInputs(page)
+  await page.getByRole('button', { name: 'Call Method' }).click()
+  await expect(page.getByText('uint32(42)', { exact: true })).toBeVisible()
   await page.getByRole('button', { name: 'Disconnect' }).click()
 
   await expect(page.getByRole('heading', { name: 'MethodIO', level: 2 })).toHaveCount(0)
+  await expect(page.getByLabel('Summand1')).toHaveCount(0)
+  await expect(page.getByText('uint32(42)', { exact: true })).toHaveCount(0)
   await expect(page.getByRole('heading', { name: 'Connect to an OPC UA Server' })).toBeVisible()
 })

--- a/frontend/tests/ui/method-call.spec.ts
+++ b/frontend/tests/ui/method-call.spec.ts
@@ -35,6 +35,7 @@ async function stubMethodAPI(page: Page, options: { details?: unknown; detailsEr
       CallMethod: call,
       ClearVariableNodeInspection: () => Promise.resolve(),
       Disconnect: () => Promise.resolve(),
+      InspectVariableNode: () => Promise.resolve(),
       GetSessionSafety: () => Promise.resolve({ connected: false, readOnlyMode: true })
     } } }
   }, {
@@ -165,6 +166,20 @@ test('a Good result displays ordered raw outputs and input changes clear stale r
   await expect(page.getByText('Method call completed: StatusGood', { exact: true })).toBeVisible()
   await page.getByLabel('Summand1').fill('21')
   await expect(page.getByText('uint32(42)', { exact: true })).toHaveCount(0)
+})
+
+test('selecting another Address Space node clears the Method result and transient inputs', async ({ page }) => {
+  await stubMethodAPI(page)
+  await openMethod(page)
+  await enterMethodInputs(page)
+  await page.getByRole('button', { name: 'Call Method' }).click()
+  await expect(page.getByText('uint32(42)', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Filler Temperature Variable', exact: true }).click()
+
+  await expect(page.getByRole('heading', { name: 'MethodIO', level: 2 })).toHaveCount(0)
+  await expect(page.getByText('uint32(42)', { exact: true })).toHaveCount(0)
+  await expect(page.getByLabel('Summand1')).toHaveCount(0)
 })
 
 test('non-Good and transport failures remain visible inline with concise toasts', async ({ page }) => {

--- a/frontend/tests/ui/method-call.spec.ts
+++ b/frontend/tests/ui/method-call.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test, type Page } from 'playwright/test'
+
+const methodDetails = {
+  ObjectNodeID: 'ns=3;s=Demo.CTT.Methods',
+  MethodNodeID: 'ns=3;s=Demo.CTT.Methods.MethodIO',
+  Description: 'Adds 2 unsigned integers',
+  Executable: true,
+  UserExecutable: true,
+  InputArguments: [
+    { Name: 'Summand1', DataType: 'UInt32', DataTypeID: 'i=7', ValueRank: 'Scalar', Description: 'First unsigned integer', ArrayDimensions: [], Supported: true },
+    { Name: 'Summand2', DataType: 'UInt32', DataTypeID: 'i=7', ValueRank: 'Scalar', Description: 'Second unsigned integer', ArrayDimensions: [], Supported: true }
+  ],
+  OutputArguments: [
+    { Name: 'Sum', DataType: 'UInt32', DataTypeID: 'i=7', ValueRank: 'Scalar', Description: 'The sum', ArrayDimensions: [], Supported: true }
+  ]
+}
+
+async function stubMethodAPI(page: Page, options: { details?: unknown; detailsError?: string; result?: unknown; callError?: string; deferredCall?: boolean } = {}) {
+  await page.addInitScript(({ details, detailsError, result, callError, deferredCall }) => {
+    const testWindow = window as typeof window & { go: unknown; methodCalls: unknown[]; methodDetailRequests: unknown[]; releaseMethodCall?: () => void }
+    testWindow.methodCalls = []
+    testWindow.methodDetailRequests = []
+    const getDetails = (request: unknown) => {
+      testWindow.methodDetailRequests.push(request)
+      return detailsError ? Promise.reject(new Error(detailsError)) : Promise.resolve(details)
+    }
+    const call = (request: unknown) => {
+      testWindow.methodCalls.push(request)
+      if (callError) return Promise.reject(new Error(callError))
+      if (deferredCall) return new Promise(resolve => { testWindow.releaseMethodCall = () => resolve(result) })
+      return Promise.resolve(result)
+    }
+    testWindow.go = { main: { App: {
+      GetMethodDetails: getDetails,
+      CallMethod: call,
+      ClearVariableNodeInspection: () => Promise.resolve(),
+      Disconnect: () => Promise.resolve(),
+      GetSessionSafety: () => Promise.resolve({ connected: false, readOnlyMode: true })
+    } } }
+  }, {
+    details: options.details ?? methodDetails,
+    detailsError: options.detailsError ?? '',
+    result: options.result ?? { StatusCode: 'StatusGood', InputArgumentResults: ['StatusGood', 'StatusGood'], OutputArguments: [{ DataType: 'UInt32', Value: 'uint32(42)' }] },
+    callError: options.callError ?? '',
+    deferredCall: options.deferredCall ?? false
+  })
+}
+
+async function openMethod(page: Page, source: 'tree' | 'search' = 'tree', state = 'method-call') {
+  await page.goto(`/?screenshot=${state}`)
+  if (source === 'tree') await page.getByRole('button', { name: 'MethodIO Method', exact: true }).click()
+  else await page.getByRole('button', { name: /^play_circle MethodIO/ }).click()
+  await expect(page.getByRole('heading', { name: 'MethodIO', level: 2 })).toBeVisible()
+}
+
+async function enterMethodInputs(page: Page) {
+  await page.getByLabel('Summand1').fill('20')
+  await page.getByLabel('Summand2').fill('22')
+}
+
+test('Method Nodes have a distinct affordance and inspection remains available in Read-Only Mode', async ({ page }) => {
+  await stubMethodAPI(page)
+  await openMethod(page, 'tree', 'method-call-read-only')
+
+  await expect(page.getByText('Method Call', { exact: true })).toBeVisible()
+  await expect(page.getByText('Adds 2 unsigned integers', { exact: true })).toBeVisible()
+  await expect(page.getByRole('definition').filter({ hasText: methodDetails.ObjectNodeID }).first()).toBeVisible()
+  await expect(page.getByRole('definition').filter({ hasText: methodDetails.MethodNodeID }).first()).toBeVisible()
+  await expect(page.getByText('Executable for this session', { exact: true })).toBeVisible()
+  await expect(page.getByText('First unsigned integer', { exact: true })).toBeVisible()
+  await expect(page.getByText('Sum', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Call Method' })).toBeDisabled()
+  await expect(page.getByText('Read-Only Mode is active.', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Allow changes this session' })).toBeVisible()
+})
+
+test('search activation preserves the owning Object Node and opens the same Method Call panel', async ({ page }) => {
+  await stubMethodAPI(page)
+  await openMethod(page, 'search')
+
+  await expect.poll(() => page.evaluate(() => (window as typeof window & { methodDetailRequests: unknown[] }).methodDetailRequests)).toEqual([{
+    objectNodeID: methodDetails.ObjectNodeID,
+    methodNodeID: methodDetails.MethodNodeID
+  }])
+  await expect(page.getByRole('definition').filter({ hasText: methodDetails.ObjectNodeID }).first()).toBeVisible()
+})
+
+test('invalid and unsupported arguments show visible disabled reasons', async ({ page }) => {
+  await stubMethodAPI(page, { details: {
+    ...methodDetails,
+    InputArguments: [
+      methodDetails.InputArguments[0],
+      { Name: 'Schedule', DataType: 'DateTime', DataTypeID: 'i=13', ValueRank: 'OneDimension', Description: 'Unsupported schedule', ArrayDimensions: [4], Supported: false }
+    ]
+  } })
+  await openMethod(page)
+
+  await expect(page.getByText('Enter a value for Summand1.', { exact: true })).toBeVisible()
+  await page.getByLabel('Summand1').fill('4294967296')
+  await expect(page.getByText('Summand1 is outside UInt32 range.', { exact: true })).toBeVisible()
+  await expect(page.getByLabel('Schedule')).toBeDisabled()
+  await expect(page.getByText('Schedule uses unsupported DataType DateTime and ValueRank OneDimension.', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Call Method' })).toBeDisabled()
+})
+
+test('loading, failed metadata, and non-executable states explain why calling is blocked', async ({ page }) => {
+  await page.addInitScript(() => {
+    const testWindow = window as typeof window & { go: unknown }
+    testWindow.go = { main: { App: {
+      GetMethodDetails: () => new Promise(() => {}),
+      ClearVariableNodeInspection: () => Promise.resolve()
+    } } }
+  })
+  await page.goto('/?screenshot=method-call')
+  await page.getByRole('button', { name: 'MethodIO Method', exact: true }).click()
+  await expect(page.getByText('Method metadata is loading.', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Call Method' })).toBeDisabled()
+
+  await stubMethodAPI(page, { detailsError: 'BadSecurityModeInsufficient' })
+  await openMethod(page)
+  await expect(page.getByText('Method metadata failed to load: Error: BadSecurityModeInsufficient', { exact: true })).toBeVisible()
+
+  await stubMethodAPI(page, { details: { ...methodDetails, UserExecutable: false } })
+  await openMethod(page)
+  await expect(page.getByText('Method is not executable for the current session.', { exact: true })).toBeVisible()
+
+  await stubMethodAPI(page, { details: { ...methodDetails, Executable: false } })
+  await openMethod(page)
+  await expect(page.getByText('Method is not executable.', { exact: true })).toBeVisible()
+})
+
+test('Enter never submits and an in-flight Method call disables repeated submission', async ({ page }) => {
+  await stubMethodAPI(page, { deferredCall: true })
+  await openMethod(page)
+  await enterMethodInputs(page)
+  await page.getByLabel('Summand2').press('Enter')
+  await expect.poll(() => page.evaluate(() => (window as typeof window & { methodCalls: unknown[] }).methodCalls.length)).toBe(0)
+
+  await page.getByRole('button', { name: 'Call Method' }).click()
+  await expect(page.getByRole('button', { name: 'Calling…' })).toBeDisabled()
+  await expect(page.getByText('Method call is in progress.', { exact: true })).toBeVisible()
+  await expect.poll(() => page.evaluate(() => (window as typeof window & { methodCalls: unknown[] }).methodCalls.length)).toBe(1)
+  await page.evaluate(() => (window as typeof window & { releaseMethodCall?: () => void }).releaseMethodCall?.())
+  await expect(page.getByText('StatusGood', { exact: true }).first()).toBeVisible()
+})
+
+test('a Good result displays ordered raw outputs and input changes clear stale results', async ({ page }) => {
+  await stubMethodAPI(page)
+  await openMethod(page)
+  await enterMethodInputs(page)
+
+  const review = page.getByRole('region', { name: 'Method call review' })
+  await expect(review.getByText('Control Gateway', { exact: true })).toBeVisible()
+  await expect(review.getByText('20', { exact: true })).toBeVisible()
+  await expect(review.getByText('22', { exact: true })).toBeVisible()
+  await page.getByRole('button', { name: 'Call Method' }).click()
+
+  await expect.poll(() => page.evaluate(() => (window as typeof window & { methodCalls: unknown[] }).methodCalls)).toEqual([{
+    objectNodeID: methodDetails.ObjectNodeID,
+    methodNodeID: methodDetails.MethodNodeID,
+    inputArguments: ['20', '22']
+  }])
+  await expect(page.getByText('StatusGood', { exact: true }).first()).toBeVisible()
+  await expect(page.getByText('uint32(42)', { exact: true })).toBeVisible()
+  await expect(page.getByText('Method call completed: StatusGood', { exact: true })).toBeVisible()
+  await page.getByLabel('Summand1').fill('21')
+  await expect(page.getByText('uint32(42)', { exact: true })).toHaveCount(0)
+})
+
+test('non-Good and transport failures remain visible inline with concise toasts', async ({ page }) => {
+  await stubMethodAPI(page, { result: { StatusCode: 'BadInvalidArgument (0x80AB0000)', InputArgumentResults: ['BadTypeMismatch'], OutputArguments: [] } })
+  await openMethod(page)
+  await enterMethodInputs(page)
+  await page.getByRole('button', { name: 'Call Method' }).click()
+  await expect(page.getByText('BadInvalidArgument (0x80AB0000)', { exact: true }).first()).toBeVisible()
+  await expect(page.getByText('Method call returned BadInvalidArgument (0x80AB0000)', { exact: true })).toBeVisible()
+
+  await stubMethodAPI(page, { callError: 'transport unavailable' })
+  await openMethod(page)
+  await enterMethodInputs(page)
+  await page.getByRole('button', { name: 'Call Method' }).click()
+  await expect(page.getByText('Method call failed: Error: transport unavailable', { exact: true }).first()).toBeVisible()
+})
+
+test('disconnect clears the Method Call panel and transient inputs', async ({ page }) => {
+  await stubMethodAPI(page)
+  await openMethod(page)
+  await page.getByLabel('Summand1').fill('20')
+  await page.getByRole('button', { name: 'Disconnect' }).click()
+
+  await expect(page.getByRole('heading', { name: 'MethodIO', level: 2 })).toHaveCount(0)
+  await expect(page.getByRole('heading', { name: 'Connect to an OPC UA Server' })).toBeVisible()
+})

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -8,6 +8,8 @@ import {search} from '../models';
 
 export function BrowseChildren(arg1:string):Promise<Array<opcua.AddressNode>>;
 
+export function CallMethod(arg1:main.MethodCallRequest):Promise<opcua.MethodCallResult>;
+
 export function ClearVariableNodeInspection():Promise<void>;
 
 export function Connect(arg1:main.ConnectionRequest):Promise<void>;
@@ -19,6 +21,8 @@ export function Disconnect():Promise<void>;
 export function DiscoverEndpoints(arg1:string):Promise<Array<opcua.Endpoint>>;
 
 export function GetDiagnosticLogs():Promise<Array<main.DiagnosticLogEntry>>;
+
+export function GetMethodDetails(arg1:main.MethodNodeRequest):Promise<opcua.MethodDetails>;
 
 export function GetSavedConnections():Promise<Array<connections.SavedConnection>>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -6,6 +6,10 @@ export function BrowseChildren(arg1) {
   return window['go']['main']['App']['BrowseChildren'](arg1);
 }
 
+export function CallMethod(arg1) {
+  return window['go']['main']['App']['CallMethod'](arg1);
+}
+
 export function ClearVariableNodeInspection() {
   return window['go']['main']['App']['ClearVariableNodeInspection']();
 }
@@ -28,6 +32,10 @@ export function DiscoverEndpoints(arg1) {
 
 export function GetDiagnosticLogs() {
   return window['go']['main']['App']['GetDiagnosticLogs']();
+}
+
+export function GetMethodDetails(arg1) {
+  return window['go']['main']['App']['GetMethodDetails'](arg1);
 }
 
 export function GetSavedConnections() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -112,6 +112,36 @@ export namespace main {
 	        this.message = source["message"];
 	    }
 	}
+	export class MethodCallRequest {
+	    objectNodeID: string;
+	    methodNodeID: string;
+	    inputArguments: string[];
+
+	    static createFrom(source: any = {}) {
+	        return new MethodCallRequest(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.objectNodeID = source["objectNodeID"];
+	        this.methodNodeID = source["methodNodeID"];
+	        this.inputArguments = source["inputArguments"];
+	    }
+	}
+	export class MethodNodeRequest {
+	    objectNodeID: string;
+	    methodNodeID: string;
+
+	    static createFrom(source: any = {}) {
+	        return new MethodNodeRequest(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.objectNodeID = source["objectNodeID"];
+	        this.methodNodeID = source["methodNodeID"];
+	    }
+	}
 	export class SessionSafetyView {
 	    connected: boolean;
 	    readOnlyMode: boolean;
@@ -230,6 +260,7 @@ export namespace main {
 export namespace opcua {
 	
 	export class AddressNode {
+	    ParentNodeID: string;
 	    NodeID: string;
 	    DisplayName: string;
 	    BrowseName: string;
@@ -241,6 +272,7 @@ export namespace opcua {
 	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.ParentNodeID = source["ParentNodeID"];
 	        this.NodeID = source["NodeID"];
 	        this.DisplayName = source["DisplayName"];
 	        this.BrowseName = source["BrowseName"];
@@ -289,6 +321,120 @@ export namespace opcua {
 	        this.Status = source["Status"];
 	        this.SourceTimestamp = this.convertValues(source["SourceTimestamp"], null);
 	        this.ServerTimestamp = this.convertValues(source["ServerTimestamp"], null);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class MethodArgument {
+	    Name: string;
+	    DataType: string;
+	    DataTypeID: string;
+	    ValueRank: string;
+	    Description: string;
+	    ArrayDimensions: number[];
+	    Supported: boolean;
+
+	    static createFrom(source: any = {}) {
+	        return new MethodArgument(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.Name = source["Name"];
+	        this.DataType = source["DataType"];
+	        this.DataTypeID = source["DataTypeID"];
+	        this.ValueRank = source["ValueRank"];
+	        this.Description = source["Description"];
+	        this.ArrayDimensions = source["ArrayDimensions"];
+	        this.Supported = source["Supported"];
+	    }
+	}
+	export class MethodArgumentValue {
+	    DataType: string;
+	    Value: string;
+
+	    static createFrom(source: any = {}) {
+	        return new MethodArgumentValue(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.DataType = source["DataType"];
+	        this.Value = source["Value"];
+	    }
+	}
+	export class MethodCallResult {
+	    StatusCode: string;
+	    InputArgumentResults: string[];
+	    OutputArguments: MethodArgumentValue[];
+
+	    static createFrom(source: any = {}) {
+	        return new MethodCallResult(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.StatusCode = source["StatusCode"];
+	        this.InputArgumentResults = source["InputArgumentResults"];
+	        this.OutputArguments = this.convertValues(source["OutputArguments"], MethodArgumentValue);
+	    }
+
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class MethodDetails {
+	    ObjectNodeID: string;
+	    MethodNodeID: string;
+	    Description: string;
+	    Executable: boolean;
+	    UserExecutable: boolean;
+	    InputArguments: MethodArgument[];
+	    OutputArguments: MethodArgument[];
+
+	    static createFrom(source: any = {}) {
+	        return new MethodDetails(source);
+	    }
+
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.ObjectNodeID = source["ObjectNodeID"];
+	        this.MethodNodeID = source["MethodNodeID"];
+	        this.Description = source["Description"];
+	        this.Executable = source["Executable"];
+	        this.UserExecutable = source["UserExecutable"];
+	        this.InputArguments = this.convertValues(source["InputArguments"], MethodArgument);
+	        this.OutputArguments = this.convertValues(source["OutputArguments"], MethodArgument);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/opcua/client_method_details_test.go
+++ b/internal/opcua/client_method_details_test.go
@@ -39,6 +39,22 @@ func TestMethodAttributesExposeDescriptionAndExecutableState(t *testing.T) {
 	}
 }
 
+func TestMethodAttributesAllowUnsupportedOptionalDescription(t *testing.T) {
+	details := MethodDetails{}
+	attrs := []*ua.DataValue{
+		{Status: ua.StatusBadAttributeIDInvalid},
+		{Status: ua.StatusOK, Value: ua.MustVariant(true)},
+		{Status: ua.StatusOK, Value: ua.MustVariant(true)},
+	}
+
+	if err := applyMethodAttributes(&details, attrs); err != nil {
+		t.Fatalf("applyMethodAttributes() error = %v, want unsupported optional Description to be ignored", err)
+	}
+	if details.Description != "" || !details.Executable || !details.UserExecutable {
+		t.Fatalf("Method attributes = %#v, want empty description and executable state", details)
+	}
+}
+
 func TestMethodArgumentsPreserveDeclaredOrderAndMetadata(t *testing.T) {
 	value := ua.MustVariant([]*ua.ExtensionObject{
 		ua.NewExtensionObject(&ua.Argument{

--- a/internal/opcua/method.go
+++ b/internal/opcua/method.go
@@ -86,6 +86,9 @@ func applyMethodAttributes(details *MethodDetails, attrs []*ua.DataValue) error 
 		if attr == nil {
 			return fmt.Errorf("read Method %s: empty result", names[i])
 		}
+		if i == 0 && attr.Status == ua.StatusBadAttributeIDInvalid {
+			continue
+		}
 		if attr.Status != ua.StatusOK {
 			return fmt.Errorf("read Method %s: %w", names[i], attr.Status)
 		}
@@ -93,7 +96,9 @@ func applyMethodAttributes(details *MethodDetails, attrs []*ua.DataValue) error 
 			return fmt.Errorf("read Method %s: empty value", names[i])
 		}
 	}
-	details.Description = localizedTextValue(attrs[0].Value.Value())
+	if attrs[0].Status == ua.StatusOK {
+		details.Description = localizedTextValue(attrs[0].Value.Value())
+	}
 	var ok bool
 	details.Executable, ok = attrs[1].Value.Value().(bool)
 	if !ok {

--- a/internal/opcua/scalar.go
+++ b/internal/opcua/scalar.go
@@ -99,8 +99,15 @@ func parseFloatScalar(dataType string, target string, bitSize int) (float64, err
 		return 0, fmt.Errorf("invalid %s target value: %q", dataType, target)
 	}
 	value, err := strconv.ParseFloat(trimmed, bitSize)
-	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) || (value == 0 && decimalSignificandIsNonzero(trimmed)) {
 		return 0, fmt.Errorf("invalid %s target value: %q", dataType, target)
 	}
 	return value, nil
+}
+
+func decimalSignificandIsNonzero(value string) bool {
+	if exponent := strings.IndexAny(value, "eE"); exponent >= 0 {
+		value = value[:exponent]
+	}
+	return strings.ContainsAny(value, "123456789")
 }

--- a/internal/opcua/scalar_test.go
+++ b/internal/opcua/scalar_test.go
@@ -1,6 +1,9 @@
 package opcua
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestParseScalarValueUsesSupportedTypeRules(t *testing.T) {
 	tests := []struct {
@@ -19,8 +22,13 @@ func TestParseScalarValueUsesSupportedTypeRules(t *testing.T) {
 		{name: "UInt16", dataType: "UInt16", target: "65535", want: uint16(65535), normalized: "65535"},
 		{name: "UInt32", dataType: "UInt32", target: "4294967295", want: uint32(4294967295), normalized: "4294967295"},
 		{name: "UInt64", dataType: "UInt64", target: "18446744073709551615", want: uint64(18446744073709551615), normalized: "18446744073709551615"},
-		{name: "Float exponent", dataType: "Float", target: "1e-3", want: float32(0.001), normalized: "0.001"},
-		{name: "Double", dataType: "Double", target: "3.14", want: float64(3.14), normalized: "3.14"},
+		{name: "Float exponent", dataType: "Float", target: "1.25e-3", want: float32(0.00125), normalized: "0.00125"},
+		{name: "Float smallest subnormal", dataType: "Float", target: "1e-45", want: float32(math.SmallestNonzeroFloat32), normalized: "1e-45"},
+		{name: "Double exponent", dataType: "Double", target: "-.5E+2", want: float64(-50), normalized: "-50"},
+		{name: "Double smallest subnormal", dataType: "Double", target: "5e-324", want: math.SmallestNonzeroFloat64, normalized: "5e-324"},
+		{name: "Float integer zero", dataType: "Float", target: "0", want: float32(0), normalized: "0"},
+		{name: "Float decimal zero", dataType: "Float", target: "0.0", want: float32(0), normalized: "0"},
+		{name: "Double exponent zero", dataType: "Double", target: "0e-999", want: float64(0), normalized: "0"},
 		{name: "String preserves whitespace", dataType: "String", target: "  Pump A  ", want: "  Pump A  ", normalized: "  Pump A  "},
 		{name: "String empty", dataType: "String", target: "", want: "", normalized: ""},
 	}
@@ -48,7 +56,11 @@ func TestParseScalarValueRejectsUnsupportedAndInvalidValues(t *testing.T) {
 		{dataType: "Int32", target: "1.0"},
 		{dataType: "Byte", target: "256"},
 		{dataType: "Float", target: "0x1p2"},
+		{dataType: "Float", target: "1e50"},
+		{dataType: "Float", target: "1e-50"},
 		{dataType: "Double", target: "1_000"},
+		{dataType: "Double", target: "1e999"},
+		{dataType: "Double", target: "1e-999"},
 	}
 	for _, tt := range tests {
 		if _, err := ParseScalarValue(tt.dataType, tt.target); err == nil {


### PR DESCRIPTION
## Summary
- add distinct Method Node activation from the Address Space tree and search
- add the Method Call panel with metadata, validated inputs, safety gates, review, results, and toasts
- broaden session controls to Changes Allowed and regenerate Wails bindings
- add Playwright coverage for blocked, in-flight, success, non-Good, error, reset, and disconnect states

## Testing
- `go test ./...`
- `npm --prefix frontend run check`
- `npm --prefix frontend run test:ui`
- `npm --prefix frontend run build`

Closes #39